### PR TITLE
Update $bingo command and add $bread help

### DIFF
--- a/bread_cog.py
+++ b/bread_cog.py
@@ -550,6 +550,12 @@ class Bread_cog(commands.Cog, name="Bread"):
                 await ctx.send("That is not a recognized command. Use `$help bread` for some things you could call. If you wish to roll, use `$bread` on its own.")
 
         pass
+    
+    @bread.command(
+        hidden=True,
+    )
+    async def help(self, ctx):
+        await ctx.send_help(Bread_cog.bread)
 
     ########################################################################################################################
     #####      BREAD WIKI

--- a/talk.py
+++ b/talk.py
@@ -184,7 +184,7 @@ async def dayum(ctx):
     hidden= True,
 )
 async def bingo(ctx):
-    text = "You can find the current bingo board at https://mrsquirreldeduck.github.io/bingo/"
+    text = "You can find the current bingo board by running \"%board\""
     await ctx.send(text)
 
 # require proper punctuation for echo command


### PR DESCRIPTION
Old "$bingo" command linked to the website. This updates it so it tells the author to run "%board"
This also adds a "$bread help" command that is an alias for "$help bread". I totally did not accidentally add that to this pull request.