### PR TITLE
Disallows full rolling outside main server.

### DIFF
--- a/bread_cog.py
+++ b/bread_cog.py
@@ -1312,7 +1312,7 @@ loaf_converter""",
                 record = False
 
         #can be rolled plenty
-        elif channel_permission_levels.get(ctx.channel.name, 0) == PERMISSION_LEVEL_MAX:
+        elif channel_permission_levels.get(ctx.channel.name, 0) == PERMISSION_LEVEL_MAX and ctx.guild.id == default_guild:
             record = True
         
         # in neutral land -- NOTE-May not be reached

--- a/bread_cog.py
+++ b/bread_cog.py
@@ -550,6 +550,12 @@ class Bread_cog(commands.Cog, name="Bread"):
                 await ctx.send("That is not a recognized command. Use `$help bread` for some things you could call. If you wish to roll, use `$bread` on its own.")
 
         pass
+    
+    @bread.command(
+        hidden=True,
+    )
+    async def help(self, ctx):
+        await ctx.send_help(Bread_cog.bread)
 
     ########################################################################################################################
     #####      BREAD WIKI

--- a/talk.py
+++ b/talk.py
@@ -184,7 +184,7 @@ async def dayum(ctx):
     hidden= True,
 )
 async def bingo(ctx):
-    text = "You can find the current bingo board at https://mrsquirreldeduck.github.io/bingo/"
+    text = "You can find the current bingo board by running \"%board\""
     await ctx.send(text)
 
 # require proper punctuation for echo command


### PR DESCRIPTION
This adds a check in bread_cog.py to disallow full rolling (rolling with multirollers, compound rollers, and having all the rolls count) outside of the main server.