### PR TITLE
Disable OoaK alchemy until max rolls.

### DIFF
--- a/bread_cog.py
+++ b/bread_cog.py
@@ -3221,6 +3221,10 @@ anarchy - 1000% of your wager.
             # print(f"Available recipes are: {alchemy.recipes}")
 
             if target_emote.name in alchemy.recipes.keys():
+                if user_account.get("max_daily_rolls") < store.Daily_rolls.max_level(user_account) and target_emote.name in [emote.name for emote in values.all_one_of_a_kind]:  
+                    await ctx.reply(f"I'm sorry, but you cannot alchemize any {target_emote.text} right now.")
+                    self.currently_interacting.remove(ctx.author.id)
+                    return
                 recipe_list = alchemy.recipes[target_emote.name]
             else:
                 await ctx.reply(f"There are no recipes to create {target_emote.text}. Perhaps research has not progressed far enough.")


### PR DESCRIPTION
An ascension is essentially won once 5 MoaKs have been rolled as the players who have the MoaKs can alchemize an OoaK, split the dough, and get to max rolls. Some people strongly dislike this, as it feels cheap. This disallows OoaK alchemization until the player has achieved max rolls. The rolls required does adjust with ascensions. It should also allow for more OoaKs to be added and will disallow creation of those, too, as long as the OoaK is in values.all_one_of_a_kind.