### PR TITLE
Make negative dough gifting bricks 1 minute again

### DIFF
--- a/bread_cog.py
+++ b/bread_cog.py
@@ -2388,7 +2388,7 @@ For instance, "$bread gift Melodie 5 special_bread" would gift 5 of each special
         if (amount < 0):
             print(f"Rejecting steal request from {ctx.author.display_name}")
             await ctx.reply("Trying to steal bread? Mum won't be very happy about that.")
-            await ctx.invoke(self.bot.get_command('brick'), member=ctx.author, duration="10")
+            await ctx.invoke(self.bot.get_command('brick'), member=ctx.author, duration="1")
             return
         
         if (amount == 0):


### PR DESCRIPTION
The fact that they were 1 minute was technically a bug and they should've been 10, but it seems nearly everyone prefers them being 1. This reverts the duration back to 1 minute.