### PR TITLE
Increased LC cap by about 1,343,394,827,220,289,410.3x

### DIFF
--- a/bread/store.py
+++ b/bread/store.py
@@ -299,7 +299,7 @@ class Loaf_Converter(Store_Item):
 
     @classmethod
     def max_level(cls, user_account: account.Bread_Account = None) -> typing.Optional[int]:
-        return 69420
+        return 93258468905632490863452
 
 class Dough_Multiplier(Store_Item):
     name = "dough_multiplier"


### PR DESCRIPTION
With no SCY it would require 1,113,234,178,895,721,236,232,878,488,202,416,113,792,028,128,768 dough. With SCY7 it would require 747,954,213,945,562,705,593,965,234,260,998,326,454,018,899,016 dough.