### PR TITLE
MoaK booster odds now consistent with 1.3^x

### DIFF
--- a/bread/store.py
+++ b/bread/store.py
@@ -23,7 +23,7 @@ ascension_token_levels = [50, 150, 450, 1000]
 daily_rolls_discount_prices = [128, 124, 120, 116, 112, 108, 104, 100]
 loaf_converter_discount_prices = [256, 244, 232, 220, 208, 196, 184, 172]
 chess_piece_distribution_levels = [25, 33, 42, 50]
-moak_booster_multipliers = [1, 1.3, 1.7, 2.1, 2.8,3.7]
+moak_booster_multipliers = [1, 1.3, 1.69, 2.197, 2.8561,3.71293]
 chessatron_shadow_booster_levels = [0, 5, 10, 15, 20]
 shadow_gold_gem_luck_boost_levels = [0, 10, 20, 30, 40]
 

--- a/bread/store.py
+++ b/bread/store.py
@@ -299,7 +299,7 @@ class Loaf_Converter(Store_Item):
 
     @classmethod
     def max_level(cls, user_account: account.Bread_Account = None) -> typing.Optional[int]:
-        return 69420
+        return 093258468905632490863452
 
 class Dough_Multiplier(Store_Item):
     name = "dough_multiplier"

--- a/bread_cog.py
+++ b/bread_cog.py
@@ -2388,7 +2388,7 @@ For instance, "$bread gift Melodie 5 special_bread" would gift 5 of each special
         if (amount < 0):
             print(f"Rejecting steal request from {ctx.author.display_name}")
             await ctx.reply("Trying to steal bread? Mum won't be very happy about that.")
-            await ctx.invoke(self.bot.get_command('brick'), member=ctx.author, duration="10")
+            await ctx.invoke(self.bot.get_command('brick'), member=ctx.author, duration="1")
             return
         
         if (amount == 0):


### PR DESCRIPTION
They previously weren't, and also weren't consistent with any pattern of flooring, ceiling, or rounding. 