### PR TITLE
Allowing viewing of other ascension's leaderboards

### DIFF
--- a/bread_cog.py
+++ b/bread_cog.py
@@ -984,6 +984,7 @@ loaf_converter""",
         lifetime = False
         search_all = False
         wide_leaderboard = False
+        ascensions = []
         requester_account = self.json_interface.get_account(ctx.author.id)
 
         if "lifetime" in args:
@@ -997,6 +998,14 @@ loaf_converter""",
         if "wide" in args:
             wide_leaderboard = True
             args.remove("wide")
+        
+        for arg in args.copy():
+            if arg.startswith("a") and arg[1:].isnumeric():
+                ascensions.append(int(arg[1:]))
+                args.remove(arg)
+        
+        if len(ascensions) == 0:
+            ascensions.append(requester_account.get("prestige_level"))
 
         if len(args) > 0:
             search_value = args[0]
@@ -1081,7 +1090,7 @@ loaf_converter""",
                 if "id" not in file.keys():
                     return False
                 checked_account = self.json_interface.get_account(file["id"])
-                if requester_account.get("prestige_level") == checked_account.get("prestige_level"):
+                if checked_account.get("prestige_level") in ascensions:
                     return True
                 else:
                     return False


### PR DESCRIPTION
With the parameter "a\<ascension number>" you can view the leaderboard for a specific ascension.
If multiple parameters are provided (for example, "a1 a2 a3") then all of the ascensions will be included. So in the example anyone on a1, a2, or a3 will be included in the leaderboard.
If no ascension is provided it will use the requester's ascension.
Full command examples:
"$bread lb a1 loaf_converter" (will provide a leaderboard for loaf converters on a1)
"$bread lb a0 a1 a2 a4 a5 shiny" (will provide a leaderboard for the shiny stat, for everyone on a0, a1, a2, a3, a4 or a5)