### PR TITLE
Allows customization in black hole

### DIFF
--- a/bread/account.py
+++ b/bread/account.py
@@ -36,6 +36,7 @@ class Bread_Account:
         "auto_chessatron" : True,
         "spellcheck" : False,
         "black_hole" : 0,
+        "black_hole_conditions" : ["<:anarchy_chess:960772054746005534>", "<:gem_gold:1006498746718244944>", "14+"],
         "gifts_disabled" : False,
     }
 


### PR DESCRIPTION
I did [Duck's suggestion](https://discord.com/channels/958392331671830579/1143695072722960515) because I was bored

- ``$bread black_hole`` and ``$bread black_hole [on/off]`` remains unchanged
- ``$bread black_hole [arg1] [arg2]...`` now exists

Allowed arguments: Emotes in values.all_emotes, categories (same as ``$bread gift [category]``), ``14+``, ``lottery_win`` (shows up differently due to how it's defined in ``values.py``)

Also change for showing 14+ rolls