### PR TITLE
Fix formatting issues in non-existent brick leaderboard command.

### DIFF
--- a/enforcement.py
+++ b/enforcement.py
@@ -185,7 +185,7 @@ async def brick_leaderboard(ctx, user: discord.Member):
                     if utility.contains_ping(name):
                         name = file["username"]
                     if i == index:
-                        output += f"**{i+1}. {name}: {list_ref[id]}**\n"
+                        output += f"{i+1}. **{name}: {list_ref[id]}**\n"
                     else:
                         output += f"{i+1}. {name}: {list_ref[id]}\n"
                 else:


### PR DESCRIPTION
Looks like this was never fixed when Discord changed the formatting system, so the bold was applied to the place number, which was causing issues.