### PR TITLE
Switch '$bread wiki' to new wiki.

### DIFF
--- a/bread_cog.py
+++ b/bread_cog.py
@@ -653,7 +653,7 @@ class Bread_cog(commands.Cog, name="Bread"):
         brief="Links to the wiki."
     )
     async def wiki(self, ctx):
-        await ctx.send("The bread wiki is a repository of all information so far collected about the bread game. It can be found here:\nhttps://bread.miraheze.org/wiki/Main_Page")
+        await ctx.send("The bread wiki is a repository of all information so far collected about the bread game. It can be found here:\nhttps://bread.miraheze.org/wiki/The_Bread_Game_Wiki")
 
     ###########################################################################################################################
     ######## STATS OLD

--- a/bread_cog.py
+++ b/bread_cog.py
@@ -653,7 +653,7 @@ class Bread_cog(commands.Cog, name="Bread"):
         brief="Links to the wiki."
     )
     async def wiki(self, ctx):
-        await ctx.send("The bread wiki is a repository of all information so far collected about the bread game. It can be found here:\nhttps://the-bread-game.fandom.com/wiki/The_Bread_Game_Wiki")
+        await ctx.send("The bread wiki is a repository of all information so far collected about the bread game. It can be found here:\nhttps://bread.miraheze.org/wiki/Main_Page")
 
     ###########################################################################################################################
     ######## STATS OLD


### PR DESCRIPTION
Switched the `$bread wiki` command to the new wiki, https://bread.miraheze.org/wiki/Main_Page