### PR TITLE
Fix get_emote() breaking if the input is an empty string

### DIFF
--- a/bread/values.py
+++ b/bread/values.py
@@ -741,6 +741,8 @@ all_emotes = [normal_bread,
     ] + all_chess_pieces + misc_emotes + misc_bread_emotes + all_uniques + all_shinies + shadow_emotes
 
 def get_emote(text: str) -> typing.Optional[Emote]:
+    if len(text) == 0:
+        return None
     # return None
 
     text = text.lower()


### PR DESCRIPTION
Running `$bread black_hole :gem_gold:  3` currently will throw an error, because it tries to do `text[-1]`, which breaks with an empty string. It splits it up by spaces, so between the two spaces in a row it will check an empty string.