### PR TITLE
 A couple shop related changes.

### DIFF
--- a/bread/store.py
+++ b/bread/store.py
@@ -32,6 +32,7 @@ moak_booster_multipliers = [1, 1.3, 1.7, 2.1, 2.8,3.7]
 class Store_Item:
     name = "generic_item"
     display_name = "Generic Item" # did you just say "generic excuse"??
+    aliases = []
 
     @classmethod
     def cost(cls, user_account: account.Bread_Account) -> int:
@@ -227,7 +228,8 @@ class Welcome_Packet(Store_Item):
 
 class Daily_rolls(Store_Item):
     name = "max_daily_rolls"
-    display_name = "Extra daily roll"
+    display_name = "Extra Daily Roll"
+    aliases = ["daily roll", "extra roll"]
 
     @classmethod
     def cost(cls, user_account: account.Bread_Account) -> int:
@@ -277,6 +279,7 @@ class Daily_rolls(Store_Item):
 class Loaf_Converter(Store_Item):
     name = "loaf_converter"
     display_name = "Loaf Converter"
+    aliases = ["lc"]
 
     @classmethod
     def cost(cls, user_account: account.Bread_Account) -> int:
@@ -710,6 +713,7 @@ class Special_Bread_Pack(Store_Item):
 class Extra_Gamble(Store_Item):
     name = "extra_gamble"
     display_name = "Extra Gamble"
+    aliases = ["gamble", "gramble", "extra gramble"]
 
     @classmethod
     def cost(cls, user_account: account.Bread_Account) -> int:
@@ -794,6 +798,7 @@ class Roll_Summarizer(Store_Item):
 class Black_Hole_Technology(Custom_price_item):
     name = "black_hole"
     display_name = "Black Hole Technology"
+    aliases = ["black hole"]
 
     @classmethod
     def get_costs(cls):
@@ -907,6 +912,7 @@ class Bling(Custom_price_item):
 class LC_booster(Custom_price_item):
     name = "LC_booster"
     display_name = "Recipe Refinement"
+    aliases = ["rr"]
 
     @classmethod
     def get_costs(cls):
@@ -1031,6 +1037,7 @@ class Prestige_Store_Item(Store_Item):
 class High_Roller_Table(Prestige_Store_Item):
     name = "gamble_level"
     display_name = "High Roller Table"
+    aliases = ["hrt"]
 
     gamble_levels = [50, 500, 1500, 5000, 10000, 100000, 10000000, 1000000000, 1000000000000]
 
@@ -1063,6 +1070,7 @@ class High_Roller_Table(Prestige_Store_Item):
 class Daily_Discount_Card(Prestige_Store_Item):
     name = "max_daily_rolls_discount"
     display_name = "Daily Discount Card"
+    aliases = ["ddc"]
 
     #costs = [0, 1, 1, 1, 2, 2, 2, 3]
 
@@ -1086,6 +1094,7 @@ class Daily_Discount_Card(Prestige_Store_Item):
 class Self_Converting_Yeast(Prestige_Store_Item):
     name = "loaf_converter_discount"
     display_name = "Self Converting Yeast"
+    aliases = ["scy"]
 
     # costs = [0, 1, 1, 1, 2, 2, 2, 3]
 
@@ -1113,6 +1122,7 @@ class Self_Converting_Yeast(Prestige_Store_Item):
 class Chess_Piece_Equalizer(Prestige_Store_Item):
     name = "chess_piece_equalizer"
     display_name = "Chess Piece Equalizer"
+    aliases = "cpe"
 
     costs = [0, 1, 2, 3]
     
@@ -1136,6 +1146,7 @@ class Chess_Piece_Equalizer(Prestige_Store_Item):
 class MoaK_Booster(Prestige_Store_Item):
     name = "moak_booster"
     display_name = "MoaK Booster"
+    aliases = ["mb"]
 
     costs = [0, 2, 2, 3, 3, 4]
 
@@ -1156,6 +1167,7 @@ class MoaK_Booster(Prestige_Store_Item):
 class Chessatron_Contraption(Prestige_Store_Item):
     name = "chessatron_shadow_boost"
     display_name = "Chessatron Contraption"
+    aliases = ["cc"]
 
     costs = [0, 1, 1, 2, 2]
 
@@ -1179,6 +1191,7 @@ class Chessatron_Contraption(Prestige_Store_Item):
 class Ethereal_Shine(Prestige_Store_Item):
     name = "shadow_gold_gem_luck_boost"
     display_name = "Ethereal Shine"
+    aliases = ["es"]
 
     costs = [0, 1, 1, 2, 2]
 
@@ -1203,6 +1216,7 @@ class Ethereal_Shine(Prestige_Store_Item):
 class First_Catch(Prestige_Store_Item):
     name = "first_catch_level"
     display_name = "First Catch of the Day"
+    aliases = ["fcotd"]
 
     costs = [0, 1, 1, 2, 2, 3]
 

--- a/bread/store.py
+++ b/bread/store.py
@@ -1432,6 +1432,10 @@ class Gambit_Shop_Black_Pawn(Gambit_shop_Item):
 class Gambit_Shop_Black_Knight(Gambit_shop_Item):
     name = "gambit_shop_black_knight"
     display_name = "King's Indian Defense"
+    aliases = [
+        "Kings Indian Defense", # No apostrophe.
+        "King’s Indian Defense" # iOS apostrophe.
+    ]
     level_required = 2
     boost_item = values.black_knight
     boost_amount = 20

--- a/bread_cog.py
+++ b/bread_cog.py
@@ -2132,6 +2132,11 @@ loaf_converter""",
             if i.name.lower() == item_name_2 or i.display_name.lower() == item_name_2:
                 item = i
                 break
+            # this is for aliases
+            aliases = [option.lower() for option in i.aliases]
+            if item_name in aliases or item_name_2 in aliases:
+                item = i
+                break
         else: # if the for loop doesn't break, run this. This should run the same as an 'if item is None' check.
             await ctx.reply("Sorry, but I don't recognize that item's name.")
             return
@@ -2212,7 +2217,8 @@ loaf_converter""",
                 #text += f"\n\nYou now have **{user_account.get(values.ascension_token.text)} {values.ascension_token.text}** remaining."
             else:
                 if text is None:
-                    text = f"You have purchased a {item.display_name}! You now have {user_account.get(item.name)} of them."
+                    an = "an" if item.display_name.lower()[0] in "aeiou" else "a"
+                    text = f"You have purchased {an} {item.display_name}! You now have {user_account.get(item.name)} of them."
 
                 #text += f"\n\nYou now have **{user_account.get('total_dough')} dough** remaining."
 


### PR DESCRIPTION
Changes include:
- Adding a set of aliases that shop items can also be referred to by. (Originally suggested by Kapola in February in 2023.)
- The purchase confirmation message will now say "an" instead of "a" when appropriate.