### PR TITLE
Roll Summarizer now says how much dough you have in total. 

### DIFF
--- a/bread/rolls.py
+++ b/bread/rolls.py
@@ -389,13 +389,16 @@ def test_account():
 # with moaks, each roll is worth about 6.4 dough
 # and each LC is worth about .7 dough per roll
 
-def summarize_roll(result):
+def summarize_roll(
+        result: dict,
+        account: account.Bread_Account
+    ) -> str:
 
     removals = []
 
     output = "\tSummary of results:\n"
     if "value" in result:
-        output += f"Total gain: **{utility.smart_number(result['value'])} dough**\n"
+        output += f"Total gain: **{utility.smart_number(result['value'])} dough** (You now have **{account.get_dough()} dough**)\n"
         removals.append("value")
 
     if "gambit_shop_bonus" in result:

--- a/bread/rolls.py
+++ b/bread/rolls.py
@@ -398,7 +398,7 @@ def summarize_roll(
 
     output = "\tSummary of results:\n"
     if "value" in result:
-        output += f"Total gain: **{utility.smart_number(result['value'])} dough** (You now have **{account.get_dough()} dough**)\n"
+        output += f"Total gain: **{utility.smart_number(result['value'])} dough** (You now have **{account.get_dough()} dough**.)\n"
         removals.append("value")
 
     if "gambit_shop_bonus" in result:

--- a/bread_cog.py
+++ b/bread_cog.py
@@ -1521,7 +1521,7 @@ loaf_converter""",
             self.json_interface.set_account(ctx.author,user_account, guild = ctx.guild.id)
 
             if get_channel_permission_level(ctx) == PERMISSION_LEVEL_MAX and user_account.has("roll_summarizer"):
-                summarizer_commentary = rolls.summarize_roll(result)
+                summarizer_commentary = rolls.summarize_roll(result, user_account)
             
 
             print (f"{ctx.author.name} rolled {total_value} dough.")


### PR DESCRIPTION
Originally suggested by Kirbo in January of 2024, Roll Summarizer now says how much dough you have after the stats are applied.
It is in the following format:
"
Total gain: **### dough** (You now have **### dough**)
"