### PR TITLE
Fix negative gifting and gambling not bricking people.

### DIFF
--- a/bread_cog.py
+++ b/bread_cog.py
@@ -2737,7 +2737,7 @@ For example, "$bread gift Melodie all chess_pieces" would gift all your chess pi
         if (amount < 0):
             print(f"Rejecting steal request from {ctx.author.display_name}")
             await ctx.reply("Trying to steal bread? Mum won't be very happy about that.")
-            await ctx.invoke(self.bot.get_command('brick'), member=ctx.author, duration="1")
+            await ctx.invoke(self.bot.get_command('brick'), member=ctx.author)
             return
         
         if (amount == 0):
@@ -3033,7 +3033,7 @@ anarchy - 1000% of your wager.
                     await asyncio.sleep(2)
                 except:
                     pass 
-                await ctx.invoke(self.bot.get_command('brick'), member=ctx.author, duration=None)
+                await ctx.invoke(self.bot.get_command('brick'), member=ctx.author)
             else:
                 await utility.smart_reply(ctx, f"With a {winning_text}, you won {utility.smart_number(winnings)} dough.")
         


### PR DESCRIPTION
The change to bricks removed the `duration` argument from the brick command, so negative gifting and winning bricks from gambling both broke as they passed it as a keyword argument.