### PR TITLE
Patch 27.3 (Balance patch.)

### DIFF
--- a/bread/alchemy.py
+++ b/bread/alchemy.py
@@ -255,27 +255,28 @@ recipes = {
     "fuel": [
         {
             "cost": [(values.gem_red, 2)],
-            "requirement": [("space_level", 1)]
+            "requirement": [("space_level", 1)],
+            "result": 5
         },
         {
             "cost": [(values.gem_blue, 2)],
             "requirement": [("space_level", 1), ("fuel_research", 1)],
-            "result": 3
+            "result": 15
         },
         {
             "cost": [(values.gem_purple, 2)],
             "requirement": [("space_level", 1), ("fuel_research", 2)],
-            "result": 9
+            "result": 45
         },
         {
             "cost": [(values.gem_green, 2)],
             "requirement": [("space_level", 1), ("fuel_research", 3)],
-            "result": 27
+            "result": 135
         },
         {
             "cost": [(values.gem_gold, 2)],
             "requirement": [("space_level", 1), ("fuel_research", 4)],
-            "result": 150
+            "result": 750
         }
     ],
 

--- a/bread/alchemy.py
+++ b/bread/alchemy.py
@@ -305,7 +305,7 @@ recipes = {
     "bread": [
         {
             "cost": [(values.corrupted_bread, 10)],
-            "requirement": [("space_level", 1)]
+            "requirement": [("galaxy_move_count", 1)]
         }
     ],
 
@@ -323,7 +323,7 @@ recipes = {
 		},
         {
             "cost": [(values.corrupted_bread, 75)],
-            "requirement": [("space_level", 1)]
+            "requirement": [("galaxy_move_count", 1)]
         }
     ],
 
@@ -339,7 +339,7 @@ recipes = {
 		},
         {
             "cost": [(values.corrupted_bread, 75)],
-            "requirement": [("space_level", 1)]
+            "requirement": [("galaxy_move_count", 1)]
         }
     ],
 
@@ -355,7 +355,7 @@ recipes = {
 		},
         {
             "cost": [(values.corrupted_bread, 75)],
-            "requirement": [("space_level", 1)]
+            "requirement": [("galaxy_move_count", 1)]
         }
     ],
 
@@ -379,7 +379,7 @@ recipes = {
 		},
         {
             "cost": [(values.corrupted_bread, 25)],
-            "requirement": [("space_level", 1)]
+            "requirement": [("galaxy_move_count", 1)]
         }
     ],
 
@@ -401,7 +401,7 @@ recipes = {
 		},
         {
             "cost": [(values.corrupted_bread, 25)],
-            "requirement": [("space_level", 1)]
+            "requirement": [("galaxy_move_count", 1)]
         }
     ],
 
@@ -423,7 +423,7 @@ recipes = {
 		},
         {
             "cost": [(values.corrupted_bread, 25)],
-            "requirement": [("space_level", 1)]
+            "requirement": [("galaxy_move_count", 1)]
         }
     ],
 
@@ -445,7 +445,7 @@ recipes = {
 		},
         {
             "cost": [(values.corrupted_bread, 25)],
-            "requirement": [("space_level", 1)]
+            "requirement": [("galaxy_move_count", 1)]
         }
     ],
 
@@ -467,7 +467,7 @@ recipes = {
 		},
         {
             "cost": [(values.corrupted_bread, 25)],
-            "requirement": [("space_level", 1)]
+            "requirement": [("galaxy_move_count", 1)]
         }
     ],
 

--- a/bread/rolls.py
+++ b/bread/rolls.py
@@ -139,10 +139,12 @@ def bread_roll(
             output = utility.increment(output, "ten_breads", 1)
             output["highest_roll"] = loaf_count
         elif loaf_count == 11:
+            # an eleven bread roll?? in the bread game?? how queer!! ive never seen such a thing- i must inquire about this further with my supervisor post-haste!!
             count_commentary = "Eleven breads? How strange."
             output = utility.increment(output, "eleven_breads", 1)
             output["highest_roll"] = loaf_count
         elif loaf_count == 12:
+            # i guess we doin twelve breads now
             count_commentary = "TWELVE BREADS??"
             output = utility.increment(output, "twelve_breads", 1)
             output["highest_roll"] = loaf_count

--- a/bread/space.py
+++ b/bread/space.py
@@ -1448,7 +1448,7 @@ def get_planet_modifiers(
         raw_seed = tile.tile_seed()
         tile_seed = tile.tile_seed() + day_seed
 
-        phi = (1 + math.sqrt(5)) / 2
+        sqrt_phi = math.sqrt((1 + math.sqrt(5)) / 2)
 
         # Get the planet seed for each category.
         # These do not change per day.
@@ -1456,12 +1456,22 @@ def get_planet_modifiers(
             odds[key] = random.Random(f"{raw_seed}{key}").gauss(mu=1, sigma=deviation)
 
             if key == priority:
-                odds[key] = (abs(odds[key] - 1) + 1) * phi
+                odds[key] = (abs(odds[key] - 1) + 1) * sqrt_phi
 
         # Now to get the actual modifiers.
         # These do change per day, but tend to be around the default seeds calculated above.
         for key, value in odds.copy().items():
-            odds[key] = random.Random(f"{tile_seed}{key}").gauss(mu=value, sigma=deviation / 2.5)
+            sigma = deviation / 2.5
+
+            if key == priority:
+                sigma = deviation / 1.5
+
+            odds[key] = random.Random(f"{tile_seed}{key}").gauss(mu=value, sigma=sigma)
+
+            # Incredibly unlikely to be an issue, but this forces the priority item to be greater than 1.
+            # This prevents the priority item from being less common than normal.
+            if key == priority and odds[key] < 1:
+                odds[key] = abs(odds[key] - 1) + 1
 
 
     result = {}

--- a/bread/space.py
+++ b/bread/space.py
@@ -1804,9 +1804,6 @@ def gifting_check_user(
     
     return False
 
-
-
-
 def allowed_gifting(
         json_interface: bread_cog.JSON_interface,
         player_1: account.Bread_Account,

--- a/bread/store.py
+++ b/bread/store.py
@@ -1900,7 +1900,7 @@ class Advanced_Exploration(Space_Shop_Item):
     def cost(cls, user_account: account.Bread_Account) -> list[tuple[values.Emote, int]]:
         level = user_account.get(cls.name)
 
-        anarchy_tron = int(max(level - 4, 0))
+        anarchy_tron = int((level + 2) / 3)
         omega = int(1 + (level // 2))
         chessatron = int(100 + (level * 50))
         bread = int(50 * (4 ** (level // 2)))
@@ -1929,7 +1929,7 @@ class Advanced_Exploration(Space_Shop_Item):
     def get_cost_types(cls, user_account: account.Bread_Account, level: int = None):
         out = [values.omega_chessatron.text, values.chessatron.text, values.normal_bread.text]
 
-        if user_account.get(cls.name) >= 6:
+        if user_account.get(cls.name) >= 2:
             out.append(values.anarchy_chessatron.text)
 
         return out

--- a/bread/store.py
+++ b/bread/store.py
@@ -1620,7 +1620,7 @@ class Bread_Rocket(Space_Shop_Item):
         
         upgrades = [
             "go to space.",
-            f"upgrade your telescopes and research new methods of creating {values.fuel.text}.",
+            f"upgrade your telescopes, advance your exploration, and research new methods of creating {values.fuel.text}.",
             "use your fuel more efficiently.",
             "traverse through the galaxy.",
             "upgrade your telescopes and use your fuel more efficiently.",
@@ -1666,7 +1666,7 @@ class Bread_Rocket(Space_Shop_Item):
         unlocks = [
             "",
             "You can now view space via '$bread space map'.\nUse '$help bread space' to view a list of commands.",
-            "The Upgraded Telescopes and Fuel Research shop items have been added to the Space Shop.",
+            "The Upgraded Telescopes, Advanced Exploration, and Fuel Research shop items have been added to the Space Shop.",
             "The Engine Efficiency shop item has been added to the Space Shop.",
             "The Upgraded Autopilot shop item has been added to the Space Shop.",
             "The second tier of Upgraded Telescopes and Engine Efficiency shop items are now available to purchase.",
@@ -1933,6 +1933,15 @@ class Advanced_Exploration(Space_Shop_Item):
             out.append(values.anarchy_chessatron.text)
 
         return out
+    
+    @classmethod
+    def can_be_purchased(cls, user_account: account.Bread_Account) -> bool:
+        if not super().can_be_purchased(user_account):
+            return False
+        
+        space_level = user_account.get_space_level()
+        
+        return space_level >= 2
     
 class Engine_Efficiency(Space_Shop_Item):
     name = "engine_efficiency"

--- a/bread_cog.py
+++ b/bread_cog.py
@@ -3131,21 +3131,22 @@ For example, "$bread gift Melodie all chess_pieces" would gift all your chess pi
         
         # Space gifting checks.
         if sender_account.get_space_level() != 0 or receiver_account.get_space_level() != 0:
-            send_check = space.gifting_check_user(
-                json_interface = self.json_interface,
-                user = sender_account
-            )
-            if not send_check:
-                await ctx.reply("You aren't able to access the Trade Hub network from where you are.")
-                return
-            
-            receiver_check = space.gifting_check_user(
-                json_interface = self.json_interface,
-                user = receiver_account
-            )
-            if not receiver_check:
-                await ctx.reply("You have access to the Trade Hub network, but you can't seem to reach that person.")
-                return
+            if sender_account.get_galaxy_location(self.json_interface) != receiver_account.get_galaxy_location(self.json_interface):
+                send_check = space.gifting_check_user(
+                    json_interface = self.json_interface,
+                    user = sender_account
+                )
+                if not send_check:
+                    await ctx.reply("You aren't able to access the Trade Hub network from where you are.")
+                    return
+                
+                receiver_check = space.gifting_check_user(
+                    json_interface = self.json_interface,
+                    user = receiver_account
+                )
+                if not receiver_check:
+                    await ctx.reply("You have access to the Trade Hub network, but you can't seem to reach that person.")
+                    return
         
         if arg1 is None: # If arg1 is None, then arg2 is None as well.
             await ctx.reply("Needs an amount and what to gift.")


### PR DESCRIPTION
- Decreased average multiplier for a planet's priority item from ~1.618 to ~1.272.
- Updated the gifting restrictions in space to allow two people in one system to gift endlessly. Those not in space yet will be assumed to be at the galaxy's spawn point.
- Advanced Exploration's rocket tier requirement has been increased from 1 to 2.
- Modified the cost scheme of Advanced Exploration slightly.
- Fuel alchemy now provides 5 times the fuel it did before.
- Alchemy recipes involving :corrupted_bread: now require moving on the galaxy map at least once in order to be shown and usable.