### PR TITLE
Patch 27.6

### DIFF
--- a/bread/alchemy.py
+++ b/bread/alchemy.py
@@ -35,7 +35,7 @@ recipes = {
             "cost": [(values.black_pawn, 3)]
         },
         {
-            "cost": [(values.gem_red, 2)]
+            "cost": [(values.gem_red, 1)]
         }
     ],
     "Wrook": [
@@ -52,7 +52,7 @@ recipes = {
             "cost": [(values.black_rook, 2), (values.waffle, 75)]
         },
         {
-            "cost": [(values.gem_red, 2)]
+            "cost": [(values.gem_red, 1)]
         }
     ],
         "Wknight": [
@@ -69,7 +69,7 @@ recipes = {
 			"cost": [(values.black_knight, 2), (values.bagel, 75)]
 		},
         {
-			"cost": [(values.gem_red, 2)]
+			"cost": [(values.gem_red, 1)]
 		}
     ],
 
@@ -87,7 +87,7 @@ recipes = {
 			"cost": [(values.black_bishop, 2), (values.doughnut, 75)]
 		},
         {
-			"cost": [(values.gem_red, 2)]
+			"cost": [(values.gem_red, 1)]
 		}
     ],
 
@@ -105,7 +105,7 @@ recipes = {
 			"cost": [(values.black_queen, 2), (values.doughnut, 75)]
 		},
         {
-			"cost": [(values.gem_red, 2)]
+			"cost": [(values.gem_red, 1)]
 		}
     ],
 
@@ -123,7 +123,7 @@ recipes = {
 			"cost": [(values.black_king, 2), (values.bagel, 75)]
 		},
         {
-			"cost": [(values.gem_red, 2)]
+			"cost": [(values.gem_red, 1)]
 		}
     ],
 
@@ -134,7 +134,7 @@ recipes = {
 			"cost": [(values.white_pawn, 1)]
 		},
         {
-			"cost": [(values.gem_red, 2)]
+			"cost": [(values.gem_red, 1)]
 		}
     ],
 
@@ -143,7 +143,7 @@ recipes = {
 			"cost": [(values.white_rook, 1)]
 		},
         {
-			"cost": [(values.gem_red, 2)]
+			"cost": [(values.gem_red, 1)]
 		}
     ],
 
@@ -152,7 +152,7 @@ recipes = {
 			"cost": [(values.white_knight, 1)]
 		},
         {
-			"cost": [(values.gem_red, 2)]
+			"cost": [(values.gem_red, 1)]
 		}
     ],
 
@@ -161,7 +161,7 @@ recipes = {
 			"cost": [(values.white_bishop, 1)]
 		},
         {
-			"cost": [(values.gem_red, 2)]
+			"cost": [(values.gem_red, 1)]
 		}
     ],
 
@@ -170,7 +170,7 @@ recipes = {
 			"cost": [(values.white_queen, 1)]
 		},
         {
-			"cost": [(values.gem_red, 2)]
+			"cost": [(values.gem_red, 1)]
 		}
     ],
 
@@ -179,7 +179,7 @@ recipes = {
 			"cost": [(values.white_king, 1)]
 		},
         {
-			"cost": [(values.gem_red, 2)]
+			"cost": [(values.gem_red, 1)]
 		}
     ],
 

--- a/bread/projects.py
+++ b/bread/projects.py
@@ -1050,7 +1050,7 @@ class Appease_The_French(Project):
 
         amount = rng.randint(10, 20) * 1920
 
-        return [(values.stuffed_flatbread.text, amount)]
+        return [(values.french_bread.text, amount)]
     
     @classmethod
     def get_reward(

--- a/bread_cog.py
+++ b/bread_cog.py
@@ -5970,18 +5970,29 @@ anarchy - 1000% of your wager.
         #########################################################
 
         acceptable_maps = [
-            "system",
-            "galaxy",
-            "wormhole"
+            "system", "s",
+            "galaxy", "g",
+            "wormhole", "w"
         ]
-        if move_map not in acceptable_maps:
-            move_map = None
-        
-        if move_map is None:
-            await ctx.reply("Autopilot error:\nFailure to specify the 'galaxy' or 'system' map.")
+
+        if move_map in acceptable_maps:
+            if move_map == "s":
+                move_map = "system"
+            elif move_map == "g":
+                move_map = "galaxy"
+            elif move_map == "w":
+                move_map = "wormhole"
+        elif confirm is None:
+            confirm = move_location
+            move_location = move_map
+            move_map = "system"
+        else:
+            await ctx.reply("Autopilot error:\nUnrecognized map to move on.")
 
             self.remove_from_interacting(ctx.author.id)
             return
+        
+        #########################################################
 
         confirm_text = ["yes", "y", "confirm"]
         cancel_text = ["no", "n", "cancel"]

--- a/bread_cog.py
+++ b/bread_cog.py
@@ -3141,7 +3141,8 @@ For example, "$bread gift Melodie all chess_pieces" would gift all your chess pi
             return
         
         # Space gifting checks.
-        if sender_account.get_space_level() != 0 or receiver_account.get_space_level() != 0:
+        if (sender_account.get_space_level() != 0 or receiver_account.get_space_level() != 0) and \
+            (sender_account.get_prestige_level() == receiver_account.get_prestige_level()): # Space related checks should only run if the two accounts are on the same ascension.
             if sender_account.get_galaxy_location(self.json_interface) != receiver_account.get_galaxy_location(self.json_interface):
                 send_check = space.gifting_check_user(
                     json_interface = self.json_interface,


### PR DESCRIPTION
- Fix issues with gifting down ascensions while in space.
- '$bread space move' no longer requires providing a map to move on, and will default to the system map if none is provided.
- '$bread space move' now allows 's' as an alias for 'system' and 'g' for 'galaxy'
- Reverted the red gem to chess piece nerf, so 1 red gem can now be converted to any chess piece.