### PR TITLE
Patch 27.7

### DIFF
--- a/bread/account.py
+++ b/bread/account.py
@@ -521,8 +521,8 @@ class Bread_Account:
             include_prestige_boost: bool = True
         ) -> int:
         """Calulcates the amount of dough this player gets for each anarchy chessatron."""
-        amount = values.anarchy_chessatron.value
-        amount += (self.get(values.anarchy_omega_chessatron.text) * 50_000) * self.get_shadowmega_boost_amount()
+        multiplier = 350 + (self.get(values.anarchy_omega_chessatron.text) * 25) * self.get_shadowmega_boost_amount()
+        amount = self.get_chessatron_dough_amount(include_prestige_boost=False) * multiplier
         
         if include_prestige_boost:
             prestige_mult = self.get_prestige_multiplier()

--- a/bread/alchemy.py
+++ b/bread/alchemy.py
@@ -487,7 +487,7 @@ recipes = {
             "requirement": [("space_level", 1)]
         },
         {
-            "cost": [(values.white_pawn, 250), (values.gem_green, 10)],
+            "cost": [(values.white_pawn, 1000), (values.gem_green, 10)],
             "requirement": [("space_level", 1)]
         }
     ],
@@ -510,7 +510,7 @@ recipes = {
             "requirement": [("space_level", 1)]
         },
         {
-            "cost": [(values.white_knight, 250), (values.gem_green, 10)],
+            "cost": [(values.white_knight, 1000), (values.gem_green, 10)],
             "requirement": [("space_level", 1)]
         }
     ],
@@ -533,7 +533,7 @@ recipes = {
             "requirement": [("space_level", 1)]
         },
         {
-            "cost": [(values.white_bishop, 250), (values.gem_green, 10)],
+            "cost": [(values.white_bishop, 1000), (values.gem_green, 10)],
             "requirement": [("space_level", 1)]
         }
     ],
@@ -556,7 +556,7 @@ recipes = {
             "requirement": [("space_level", 1)]
         },
         {
-            "cost": [(values.white_rook, 250), (values.gem_green, 10)],
+            "cost": [(values.white_rook, 1000), (values.gem_green, 10)],
             "requirement": [("space_level", 1)]
         }
     ],
@@ -579,7 +579,7 @@ recipes = {
             "requirement": [("space_level", 1)]
         },
         {
-            "cost": [(values.white_queen, 250), (values.gem_green, 10)],
+            "cost": [(values.white_queen, 1000), (values.gem_green, 10)],
             "requirement": [("space_level", 1)]
         }
     ],
@@ -602,7 +602,7 @@ recipes = {
             "requirement": [("space_level", 1)]
         },
         {
-            "cost": [(values.white_king, 250), (values.gem_green, 10)],
+            "cost": [(values.white_king, 1000), (values.gem_green, 10)],
             "requirement": [("space_level", 1)]
         }
     ],
@@ -615,7 +615,7 @@ recipes = {
             "requirement": [("space_level", 1)]
         },
         {
-            "cost": [(values.black_pawn, 250), (values.gem_green, 10)],
+            "cost": [(values.black_pawn, 1000), (values.gem_green, 10)],
             "requirement": [("space_level", 1)]
         }
     ],
@@ -626,7 +626,7 @@ recipes = {
             "requirement": [("space_level", 1)]
         },
         {
-            "cost": [(values.black_knight, 250), (values.gem_green, 10)],
+            "cost": [(values.black_knight, 1000), (values.gem_green, 10)],
             "requirement": [("space_level", 1)]
         }
     ],
@@ -637,7 +637,7 @@ recipes = {
             "requirement": [("space_level", 1)]
         },
         {
-            "cost": [(values.black_bishop, 250), (values.gem_green, 10)],
+            "cost": [(values.black_bishop, 1000), (values.gem_green, 10)],
             "requirement": [("space_level", 1)]
         }
     ],
@@ -648,7 +648,7 @@ recipes = {
             "requirement": [("space_level", 1)]
         },
         {
-            "cost": [(values.black_rook, 250), (values.gem_green, 10)],
+            "cost": [(values.black_rook, 1000), (values.gem_green, 10)],
             "requirement": [("space_level", 1)]
         }
     ],
@@ -659,7 +659,7 @@ recipes = {
             "requirement": [("space_level", 1)]
         },
         {
-            "cost": [(values.black_queen, 250), (values.gem_green, 10)],
+            "cost": [(values.black_queen, 1000), (values.gem_green, 10)],
             "requirement": [("space_level", 1)]
         }
     ],
@@ -670,7 +670,7 @@ recipes = {
             "requirement": [("space_level", 1)]
         },
         {
-            "cost": [(values.black_king, 250), (values.gem_green, 10)],
+            "cost": [(values.black_king, 1000), (values.gem_green, 10)],
             "requirement": [("space_level", 1)]
         }
     ],

--- a/bread/values.py
+++ b/bread/values.py
@@ -552,9 +552,9 @@ class Anarchy_Piece_Emote(Emote):
         self.text = text
         self.name = name
         if isWhite:
-            self.value = 3600
+            self.value = 36000
         else:
-            self.value = 1800
+            self.value = 18000
         self.attributes = ["anarchy_pieces"]
         self.awards_value = False
         self.alchemy_value = self.value

--- a/bread/values.py
+++ b/bread/values.py
@@ -564,84 +564,84 @@ anarchy_white_pawn = Anarchy_Piece_Emote(
     name="Wpawnanarchy",
     text = "<:Wpawnanarchy:971046978349858936>",
     isWhite=True,
-    alternate_names = ["Wpawn_anarchy", "anarchy_Wpawn"]
+    alternate_names = ["Wpawn_anarchy", "anarchy_Wpawn", "anarchyWpawn"]
 )
 
 anarchy_white_rook = Anarchy_Piece_Emote(
     name="Wrookanarchy",
     text = "<:Wrookanarchy:971047003402403862>",
     isWhite=True,
-    alternate_names = ["Wrook_anarchy", "anarchy_Wrook"]
+    alternate_names = ["Wrook_anarchy", "anarchy_Wrook", "anarchyWrook"]
 )
 
 anarchy_white_bishop = Anarchy_Piece_Emote(
     name="Wbishopanarchy",
     text = "<:Wbishopanarchy:971046928395665448>",
     isWhite=True,
-    alternate_names = ["Wbishop_anarchy", "anarchy_Wbishop"]
+    alternate_names = ["Wbishop_anarchy", "anarchy_Wbishop", "anarchyWbishop"]
 )
 
 anarchy_white_knight = Anarchy_Piece_Emote(
     name="Wknightanarchy",
     text = "<:Wknightanarchy:971046961811714158>",
     isWhite=True,
-    alternate_names = ["Wknight_anarchy", "anarchy_Wknight"]
+    alternate_names = ["Wknight_anarchy", "anarchy_Wknight", "anarchyWknight"]
 )
 
 anarchy_white_queen = Anarchy_Piece_Emote(
     name="Wqueenanarchy",
     text = "<:Wqueenanarchy:971046990312013844>",
     isWhite=True,
-    alternate_names = ["Wqueen_anarchy", "anarchy_Wqueen"]
+    alternate_names = ["Wqueen_anarchy", "anarchy_Wqueen", "anarchyWqueen"]
 )
 
 anarchy_white_king = Anarchy_Piece_Emote(
     name="Wkinganarchy",
     text = "<:Wkinganarchy:971046942144602172>",
     isWhite=True,
-    alternate_names = ["Wking_anarchy", "anarchy_Wking"]
+    alternate_names = ["Wking_anarchy", "anarchy_Wking", "anarchyWking"]
 )
 
 anarchy_black_pawn = Anarchy_Piece_Emote(
     name="Bpawnanarchy",
     text = "<:Bpawnanarchy:971046900038004736>",
     isWhite=False,
-    alternate_names = ["Bpawn_anarchy", "anarchy_Bpawn"]
+    alternate_names = ["Bpawn_anarchy", "anarchy_Bpawn", "anarchyBpawn"]
 )
 
 anarchy_black_rook = Anarchy_Piece_Emote(
     name="Brookanarchy",
     text = "<:Brookanarchy:971046920166457364>",
     isWhite=False,
-    alternate_names = ["Brook_anarchy", "anarchy_Brook"]
+    alternate_names = ["Brook_anarchy", "anarchy_Brook", "anarchyBrook"]
 )
 
 anarchy_black_bishop = Anarchy_Piece_Emote(
     name="Bbishopanarchy",
     text = "<:Bbishopanarchy:971046862134050887>",
     isWhite=False,
-    alternate_names = ["Bbishop_anarchy", "anarchy_Bbishop"]
+    alternate_names = ["Bbishop_anarchy", "anarchy_Bbishop", "anarchyBbishop"]
 )
 
 anarchy_black_knight = Anarchy_Piece_Emote(
     name="Bknightanarchy",
     text = "<:Bknightanarchy:971046888486891642>",
     isWhite=False,
-    alternate_names = ["Bknight_anarchy", "anarchy_Bknight"]
+    alternate_names = ["Bknight_anarchy", "anarchy_Bknight", "anarchyBknight"]
 )
 
 anarchy_black_queen = Anarchy_Piece_Emote(
     name="Bqueenanarchy",
     text = "<:Bqueenanarchy:971046911551356948>",
     isWhite=False,
-    alternate_names = ["Bqueen_anarchy", "anarchy_Bqueen"]
+    alternate_names = ["Bqueen_anarchy", "anarchy_Bqueen", "anarchyBqueen"]
 )
 
 anarchy_black_king = Anarchy_Piece_Emote(
     name="Bkinganarchy",
     text = "<:Bkinganarchy:971046879540445275>",
     isWhite=False,
-    alternate_names = ["Bking_anarchy", "anarchy_Bking"]
+    alternate_names = ["Bking_anarchy", "anarchy_Bking", "anarchyBking"]
 )
 
 all_anarchy_pieces = [

--- a/bread/values.py
+++ b/bread/values.py
@@ -334,7 +334,7 @@ omega_chessatron = Emote(
 
 anarchy_chessatron = Emote(
     text="<:anarchy_chessatron:1271191972627087370>",
-    value=100_000,
+    value=100_000, # Doesn't really do much since the anarchy tron dough equation was changed.
     name="anarchy_chessatron",
     attributes=["unique", "full_anarchy_set"],
     awards_value = True
@@ -342,7 +342,7 @@ anarchy_chessatron = Emote(
 
 anarchy_omega_chessatron = Emote(
     text="<:anarchy_omega_chessatron:1271191852330123274>",
-    value=250_000,
+    value=31_004_150,
     name="anarchy_omega_chessatron",
     attributes=["unique"],
     awards_value = True,

--- a/bread/values.py
+++ b/bread/values.py
@@ -563,73 +563,85 @@ class Anarchy_Piece_Emote(Emote):
 anarchy_white_pawn = Anarchy_Piece_Emote(
     name="Wpawnanarchy",
     text = "<:Wpawnanarchy:971046978349858936>",
-    isWhite=True
+    isWhite=True,
+    alternate_names = ["Wpawn_anarchy", "anarchy_Wpawn"]
 )
 
 anarchy_white_rook = Anarchy_Piece_Emote(
     name="Wrookanarchy",
     text = "<:Wrookanarchy:971047003402403862>",
-    isWhite=True
+    isWhite=True,
+    alternate_names = ["Wrook_anarchy", "anarchy_Wrook"]
 )
 
 anarchy_white_bishop = Anarchy_Piece_Emote(
     name="Wbishopanarchy",
     text = "<:Wbishopanarchy:971046928395665448>",
-    isWhite=True
+    isWhite=True,
+    alternate_names = ["Wbishop_anarchy", "anarchy_Wbishop"]
 )
 
 anarchy_white_knight = Anarchy_Piece_Emote(
     name="Wknightanarchy",
     text = "<:Wknightanarchy:971046961811714158>",
-    isWhite=True
+    isWhite=True,
+    alternate_names = ["Wknight_anarchy", "anarchy_Wknight"]
 )
 
 anarchy_white_queen = Anarchy_Piece_Emote(
     name="Wqueenanarchy",
     text = "<:Wqueenanarchy:971046990312013844>",
-    isWhite=True
+    isWhite=True,
+    alternate_names = ["Wqueen_anarchy", "anarchy_Wqueen"]
 )
 
 anarchy_white_king = Anarchy_Piece_Emote(
     name="Wkinganarchy",
     text = "<:Wkinganarchy:971046942144602172>",
-    isWhite=True
+    isWhite=True,
+    alternate_names = ["Wking_anarchy", "anarchy_Wking"]
 )
 
 anarchy_black_pawn = Anarchy_Piece_Emote(
     name="Bpawnanarchy",
     text = "<:Bpawnanarchy:971046900038004736>",
-    isWhite=False
+    isWhite=False,
+    alternate_names = ["Bpawn_anarchy", "anarchy_Bpawn"]
 )
 
 anarchy_black_rook = Anarchy_Piece_Emote(
     name="Brookanarchy",
     text = "<:Brookanarchy:971046920166457364>",
-    isWhite=False
+    isWhite=False,
+    alternate_names = ["Brook_anarchy", "anarchy_Brook"]
 )
 
 anarchy_black_bishop = Anarchy_Piece_Emote(
     name="Bbishopanarchy",
     text = "<:Bbishopanarchy:971046862134050887>",
-    isWhite=False
+    isWhite=False,
+    alternate_names = ["Bbishop_anarchy", "anarchy_Bbishop"]
 )
 
 anarchy_black_knight = Anarchy_Piece_Emote(
     name="Bknightanarchy",
-    text =  "<:Bknightanarchy:971046888486891642>",
-    isWhite=False
+    text = "<:Bknightanarchy:971046888486891642>",
+    isWhite=False,
+    alternate_names = ["Bknight_anarchy", "anarchy_Bknight"]
 )
 
 anarchy_black_queen = Anarchy_Piece_Emote(
     name="Bqueenanarchy",
-    text =  "<:Bqueenanarchy:971046911551356948>",
-    isWhite=False
+    text = "<:Bqueenanarchy:971046911551356948>",
+    isWhite=False,
+    alternate_names = ["Bqueen_anarchy", "anarchy_Bqueen"]
 )
 
 anarchy_black_king = Anarchy_Piece_Emote(
     name="Bkinganarchy",
-    text =  "<:Bkinganarchy:971046879540445275>",
-    isWhite=False
+    text = "<:Bkinganarchy:971046879540445275>",
+    isWhite=False,
+    alternate_names = ["Bking_anarchy", "anarchy_Bking"]
 )
 
 all_anarchy_pieces = [

--- a/bread_cog.py
+++ b/bread_cog.py
@@ -4701,9 +4701,11 @@ anarchy - 1000% of your wager.
                     self.remove_from_interacting(ctx.author.id)
                     return
                 
-                if "yes" in msg.content.lower():
+                content = msg.content.lower()
+                
+                if any([i in content for i in ["yes", "y", "confirm"]]):
                     pass
-                elif "no" in msg.content.lower():
+                elif any([i in content for i in ["no", "n", "deny"]]):
                     await utility.smart_reply(ctx, "You have rejected this recipe.")
                     self.remove_from_interacting(ctx.author.id)
                     return


### PR DESCRIPTION
- Increase amount of dough Anarchy Chess Pieces reward.
- Increased the amount of regular chess pieces required for the Chess Piece -> Anarchy Chess Piece recipe.
- Add some aliases for anarchy chess pieces.
- You can finally use 'y' or 'confirm' instead of 'yes' when doing multi-message alchemy.
- Changed the dough reward for the creation of Anarchy Chessatrons.