### PR TITLE
Patch 27.11

### DIFF
--- a/bread/account.py
+++ b/bread/account.py
@@ -443,7 +443,7 @@ class Bread_Account:
     
     def get_projects_credits_cap(self: typing.Self) -> int:
         """Returns the maximum amount of Trade Hub credits this account can have."""
-        return 2000
+        return 2000 + self.get(store.Project_Credit_Bonus.name) * 100
     
     def get_daily_fuel_cap(self: typing.Self) -> int:
         """Returns the maximum amount of daily fuel this account can have. This is `350 * fuel_tank + 100` where `fuel_tank` is the fuel tank level."""

--- a/bread/account.py
+++ b/bread/account.py
@@ -599,6 +599,22 @@ class Bread_Account:
         multiplier = self.get_corruption_negation_multiplier()
 
         return base_chance * multiplier
+    
+    def get_anarchy_corruption_chance(
+            self: typing.Self,
+            json_interface: bread_cog.JSON_interface
+        ) -> float:
+        """Provides the chance of an anarchy piece becoming corrupted. Is going to be a float between 0 and 1."""
+        if self.get_space_level() < 1:
+            return 0.0
+        
+        xpos, ypos = self.get_galaxy_location(json_interface=json_interface)
+
+        return space.get_anarchy_corruption_chance(
+            xpos - space.MAP_RADIUS,
+            ypos - space.MAP_RADIUS
+        )
+        
 
     def get_galaxy_tile(
             self: typing.Self,

--- a/bread/account.py
+++ b/bread/account.py
@@ -443,7 +443,7 @@ class Bread_Account:
     
     def get_projects_credits_cap(self: typing.Self) -> int:
         """Returns the maximum amount of Trade Hub credits this account can have."""
-        return 2000 + self.get(store.Project_Credit_Bonus.name) * 100
+        return 2000 + self.get(store.Payment_Bonus.name) * 100
     
     def get_daily_fuel_cap(self: typing.Self) -> int:
         """Returns the maximum amount of daily fuel this account can have. This is `350 * fuel_tank + 100` where `fuel_tank` is the fuel tank level."""

--- a/bread/generation.py
+++ b/bread/generation.py
@@ -71,6 +71,10 @@ PLANET_OPTIONS = {
 ####################################
 ### GALAXY GENERATION UTILITIES
 
+def position_check(x: int, y: int) -> bool:
+    """Checks if the given x and y coordinates are in the galaxy at all."""
+    return (x ** 2 + y ** 2) <= MAP_RADIUS_SQUARED
+
 def generate_gradients(galaxy_seed: str) -> list:
     """Generates the gradient info for the galaxy.
 
@@ -310,7 +314,7 @@ def get_spot(
         int: What is on the given point. 0 is nothing, 1 is a system without a trade hub, 2 is a system with a trade hub.
     """
     
-    if (x ** 2 + y ** 2) > MAP_RADIUS_SQUARED:
+    if not position_check(x, y):
         return 0
 
     rng = core_spot(
@@ -677,7 +681,7 @@ def generate_system(
             "ypos": planet_y,
             "distance": planet_distance,
             "angle": planet_angle,
-            "type": planet_type, # what type of item is prioritized
+            "type": planet_type.text, # what type of item is prioritized
             "deviation": deviation # how much variation there is in the roll multipliers
         })
     

--- a/bread/projects.py
+++ b/bread/projects.py
@@ -22,7 +22,8 @@ class Project:
             day_seed: str,
             system_tile: space.SystemTradeHub,
             compress_description: bool = False,
-            completed: bool = False
+            completed: bool = False,
+            item_information: dict = None
         ) -> str:
         """Returns a string that represents this project, it includes the name and description, as well as some text if the project has been completed."""
         name = cls.name(day_seed, system_tile)
@@ -45,7 +46,23 @@ class Project:
         completed_prefix = "~~" if completed else ""
         completed_suffix = "~~    COMPLETED" if completed else ""
 
-        return f"   **{completed_prefix}{name}:{completed_suffix}**\n{description_use}"
+        if item_information is not None and not completed:
+            remaining = cls.get_remaining_items(
+                day_seed = day_seed,
+                system_tile = system_tile,
+                progress_data = item_information
+            )
+
+            required = dict(cls.get_cost(
+                day_seed = day_seed,
+                system_tile = system_tile
+            ))
+
+            item_info = "(" + ", ".join(f"{utility.smart_number(required.get(key, 0) - remaining.get(key))}/{utility.smart_number(required.get(key, 0))} {key}" for key in remaining) + ")"
+        else:
+            item_info = ""
+
+        return f"   **{completed_prefix}{name}:{completed_suffix}** {item_info}\n{description_use}"
 
     # Required for subclasses.
     @classmethod

--- a/bread/projects.py
+++ b/bread/projects.py
@@ -58,7 +58,7 @@ class Project:
                 system_tile = system_tile
             ))
 
-            item_info = "(" + ", ".join(f"{utility.smart_number(required.get(key, 0) - remaining.get(key))}/{utility.smart_number(required.get(key, 0))} {key}" for key in remaining) + ")"
+            item_info = "(" + ", ".join(f"{utility.smart_number(required.get(key, 0) - remaining.get(key))}/{utility.smart_number(required.get(key, 0))} {key}" for key in remaining) + f" for {cls.get_reward_description(day_seed, system_tile)})"
         else:
             item_info = ""
 

--- a/bread/space.py
+++ b/bread/space.py
@@ -346,7 +346,7 @@ class SystemStar(SystemTile):
             f"Star type: {self.star_type.title()}"
         ]
 
-        if self.star_type == "black_hole":
+        if self.star_type == "black_hole" and detailed:
             out.append("Sensors read more interference and")
             out.append("more dynamic deviations than normal.")
 

--- a/bread/space.py
+++ b/bread/space.py
@@ -2026,12 +2026,30 @@ def get_spawn_location(
         user_account: account.Bread_Account
     ) -> tuple[int, int]:
     """Returns a 2D tuple of the spawn location in the galaxy the given player is in."""
+    map_data = json_interface.get_space_map_data(
+        ascension_id = user_account.get_prestige_level(),
+        guild = user_account.get("guild_id")
+    )
+
+    if "spawn_point" in map_data:
+        return tuple(map_data["spawn_point"])
+
     seed = json_interface.get_ascension_seed(
         ascension_id = user_account.get_prestige_level(),
         guild = user_account.get("guild_id")
     )
 
-    return generation.get_galaxy_spawn(galaxy_seed=seed)
+    location = generation.get_galaxy_spawn(galaxy_seed=seed)
+
+    map_data["spawn_point"] = list(location)
+
+    json_interface.set_space_map_data(
+        ascension_id = user_account.get_prestige_level(),
+        guild = user_account.get("guild_id"),
+        new_data = map_data
+    )
+
+    return location
 
 def get_move_cost_galaxy(
         galaxy_seed: str,

--- a/bread/space.py
+++ b/bread/space.py
@@ -1730,7 +1730,7 @@ def get_project_credits_usage(
         items_contributed (int): The amount of items that have been contributed.
         item_offset (int, optional): The number of items already contributed by the player. Defaults to 0.
     Returns:
-        int: The amount of credits to consume, between 0 and 100.
+        int: The amount of credits to consume, between 0 and 1000.
     """
 
     total_contributes = items_contributed + item_offset

--- a/bread/space.py
+++ b/bread/space.py
@@ -594,6 +594,8 @@ class GalaxyTile:
             system: bool,
             in_nebula: bool = False,
 
+            raw_system_data: dict | None = None,
+
             system_radius: int = None,
             star: SystemStar = None,
             trade_hub: SystemTradeHub = False,
@@ -626,9 +628,12 @@ class GalaxyTile:
 
         self.xpos = xpos
         self.ypos = ypos
+        self.position_id = xpos + 256 * ypos
+
         self.in_nebula = in_nebula
 
         self.system = system
+        self.raw_system_data = raw_system_data
 
         self.system_radius = system_radius
         self.star = star
@@ -687,13 +692,18 @@ class GalaxyTile:
         if not self.system:
             return None
         
-        # Get the data for the system.
-        raw_data = generation.generate_system(
-            galaxy_seed = self.galaxy_seed,
-            galaxy_xpos = self.xpos,
-            galaxy_ypos = self.ypos,
-            get_wormholes = get_wormholes
-        )
+        if self.raw_system_data is None:
+            raw_data = get_system_raw_data(
+                json_interface = json_interface,
+                guild = guild,
+                galaxy_seed = self.galaxy_seed,
+                ascension = self.ascension,
+                xpos = self.xpos,
+                ypos = self.ypos,
+                load_wormholes = get_wormholes
+            )
+
+            self.raw_system_data = raw_data
 
         # If the generated data is None, then return.
         # It should only be None if there isn't a system here, which should be prevented earlier, but just in case.
@@ -780,7 +790,7 @@ class GalaxyTile:
                 system_xpos = planet_data.get("xpos", 1),
                 system_ypos = planet_data.get("ypos", 1),
 
-                planet_type = planet_data.get("type"),
+                planet_type = values.get_emote(planet_data.get("type")),
                 planet_distance = planet_data.get("distance"),
                 planet_angle = planet_data.get("angle"),
                 planet_deviation = planet_data.get("deviation")
@@ -896,6 +906,72 @@ class GalaxyTile:
             system_x = system_x,
             system_y = system_y
         )
+    
+    def save_to_database(
+            self: typing.Self,
+            json_interface: bread_cog.JSON_interface,
+            map_data: dict = None
+        ) -> dict:
+        if map_data is None:
+            map_data = json_interface.get_space_map_data(
+                ascension_id = self.ascension,
+                guild = self.guild
+            )
+
+        chunk = self.position_id // 8192
+        sub_chunk = self.position_id % 8192
+
+        if not has_seen_tile(
+                json_interface = json_interface,
+                guild = self.guild,
+                ascension = self.ascension,
+                xpos = self.xpos,
+                ypos = self.ypos,
+                map_data = map_data
+            ):
+            # If the tile hasn't been seen, update it.
+
+            if "seen_tiles" not in map_data:
+                map_data["seen_tiles"] = [0, 0, 0, 0, 0, 0, 0, 0]
+            
+            # Bitwise OR to update the bit without worrying about adding something and messing up other data.
+            map_data["seen_tiles"][chunk] |= 2 ** sub_chunk
+
+        if self.in_nebula and not in_nebula_database(
+                json_interface = json_interface,
+                guild = self.guild,
+                ascension = self.ascension,
+                xpos = self.xpos,
+                ypos = self.ypos,
+                map_data = map_data
+            ):
+            # If the tile has a nebula but the database doesn't think so, update it.
+
+            if "nebula_tiles" not in map_data:
+                map_data["nebula_tiles"] = [0, 0, 0, 0, 0, 0, 0, 0]
+
+            # Bitwise OR to update the bit without worrying about adding something and messing up other data.
+            map_data["nebula_tiles"][chunk] |= 2 ** sub_chunk
+        
+        if self.system:
+            if str(self.position_id) not in map_data.get("system_data", {}):
+                if self.raw_system_data is None:
+                    self.load_system_data(json_interface, self.guild, True)
+                
+                if "system_data" in map_data:
+                    map_data["system_data"][str(self.position_id)] = self.raw_system_data
+                else:
+                    map_data["system_data"] = {
+                        str(self.position_id): self.raw_system_data
+                    }
+            
+        # Set the map data to this.
+        json_interface.set_space_map_data(
+            ascension_id = self.ascension,
+            guild = self.guild,
+            new_data = map_data
+        )
+        return map_data
 
 def get_corruption_chance(
         xpos: int,
@@ -1337,6 +1413,126 @@ def generate_galaxy_seed() -> str:
     """Generates a random new galaxy seed."""
     return "{:064x}".format(random.randrange(16 ** 64)) # Random 64 digit hexadecimal number.
 
+def has_seen_tile(
+        json_interface: bread_cog.JSON_interface,
+        guild: typing.Union[discord.Guild, int, str],
+        ascension: int,
+        xpos: int,
+        ypos: int,
+        map_data: dict = None
+    ) -> bool:
+    """Returns a boolean for whether the given tile has been seen yet.
+
+    Args:
+        json_interface (bread_cog.JSON_interface): The Bread Cog's JSON interface.
+        guild (typing.Union[discord.Guild, int, str]): The guild to get the data for.
+        ascension (int): The ascension to get the data for.
+        xpos (int): The x position of the tile to check.
+        ypos (int): The x position of the tile to check.
+        map_data (dict, optional): Already fetched map data, to avoid getting the data from the JSON interface multiple times. Defaults to None.
+
+    Returns:
+        bool: Whether the given tile coordinates has been seen before.
+    """
+    if map_data is None:
+        map_data = json_interface.get_space_map_data(
+            ascension_id = ascension,
+            guild = guild
+        )
+
+    seen_data = map_data.get("seen_tiles", [0, 0, 0, 0, 0, 0, 0, 0])
+
+    tile_id = xpos + 256 * ypos
+
+    chunk = tile_id // 8192
+    
+    # Bitwise AND to get the bit on its own.
+    return bool(seen_data[chunk] & 2 ** (tile_id % 8192))
+
+def in_nebula_database(
+        json_interface: bread_cog.JSON_interface,
+        guild: typing.Union[discord.Guild, int, str],
+        ascension: int,
+        xpos: int,
+        ypos: int,
+        map_data: dict = None
+    ) -> bool:
+    """Returns a boolean for whether the given tile has been marked as in a nebula in the database.
+    
+    This will not generate anything, only check already generated data. Due to this, it should only be used if `has_seen_tile()` is also True.
+
+    Args:
+        json_interface (bread_cog.JSON_interface): The Bread Cog's JSON interface.
+        guild (typing.Union[discord.Guild, int, str]): The guild to get the data for.
+        ascension (int): The ascension to get the data for.
+        xpos (int): The x position of the tile to check.
+        ypos (int): The x position of the tile to check.
+        map_data (dict, optional): Already fetched map data, to avoid getting the data from the JSON interface multiple times. Defaults to None.
+
+    Returns:
+        bool: Whether the given tile coordinates are marked as in a nebula in the database.
+    """
+    if map_data is None:
+        map_data = json_interface.get_space_map_data(
+            ascension_id = ascension,
+            guild = guild
+        )
+
+    seen_data = map_data.get("nebula_tiles", [0, 0, 0, 0, 0, 0, 0, 0])
+
+    tile_id = xpos + 256 * ypos
+
+    chunk = tile_id // 8192
+    
+    # Bitwise AND to get the bit on its own.
+    return bool(seen_data[chunk] & 2 ** (tile_id % 8192))
+
+def get_system_raw_data(
+        json_interface: bread_cog.JSON_interface,
+        guild: typing.Union[discord.Guild, int, str],
+        galaxy_seed: str,
+        ascension: int,
+        xpos: int,
+        ypos: int,
+        load_wormholes: bool = True,
+        map_data: dict = None
+    ) -> dict:
+    """Gets the raw data for a system either from the database if it's there or by generating it.
+
+    Args:
+        json_interface (bread_cog.JSON_interface): The JSON interface to use.
+        guild (typing.Union[discord.Guild, int, str]): The guild to get the data for.
+        galaxy_seed (str): The seed of the galaxy.
+        ascension (int): The ascension for the data.
+        xpos (int): The galaxy x position of the tile to generate.
+        ypos (int): The galaxy y position of the tile to generate.
+        load_wormholes (bool, optional): Whether to load the wormholes in the system if there are any. Defaults to True.
+        map_data (dict, optional): An already fetched copy of the map data to avoid fetching it multiple times. Defaults to None.
+
+    Returns:
+        dict: The raw data for the system.
+    """
+    if map_data is None:
+        map_data = json_interface.get_space_map_data(
+            ascension_id = ascension,
+            guild = guild
+        )
+
+    tile_id = xpos + 256 * ypos
+
+    if str(tile_id) in map_data.get("system_data", {}):
+        # If it's already in the database, get it from there.
+        return map_data.get("system_data", {}).get(str(tile_id))
+    else:
+        # Generate the data for the system.
+        return generation.generate_system(
+            galaxy_seed = galaxy_seed,
+            galaxy_xpos = xpos,
+            galaxy_ypos = ypos,
+            get_wormholes = load_wormholes
+        )
+
+
 def get_galaxy_coordinate(
         json_interface: bread_cog.JSON_interface,
         guild: typing.Union[discord.Guild, int, str],
@@ -1354,11 +1550,71 @@ def get_galaxy_coordinate(
         ascension (int): The ascension of this galaxy.
         xpos (int): The x position of the coordinate to get.
         ypos (int): The y position of the coordinate to get.
-        load_data (bool, optional): Whether to load the system data when making the GalaxyTile object. Defaults to False.
+        load_data (bool, optional): Whether to load the system data when making the GalaxyTile object. If the tile is not already in
+           the database and needs to be generated the data will be loaded no matter what this is. Defaults to False.
     
     Returns:
         GalaxyTile: A GalaxyTile object for the coordinate.
     """
+    # If the tile is outside the galaxy, return an empty GalaxyTile.
+    if generation.position_check(xpos, ypos):
+        return GalaxyTile(
+            galaxy_seed = galaxy_seed,
+            ascension = ascension,
+            guild = guild,
+            xpos = xpos,
+            ypos = ypos,
+            system = False,
+            in_nebula = False
+        )
+    
+    map_data = json_interface.get_space_map_data(
+        ascension_id = ascension,
+        guild = guild
+    )
+
+    if has_seen_tile(
+            json_interface = json_interface,
+            guild = guild,
+            ascension = ascension,
+            xpos = xpos,
+            ypos = ypos,
+            map_data = map_data
+        ):
+        # The tile has been seen, so get the data from storage instead of generating it again.
+        
+        in_nebula = in_nebula_database(
+            json_interface = json_interface,
+            guild = guild,
+            ascension = ascension,
+            xpos = xpos,
+            ypos = ypos,
+            map_data = map_data
+        )
+
+        tile_id = xpos + 256 * ypos
+
+        system = str(tile_id) in map_data.get("system_data", {})
+
+        out = GalaxyTile(
+            galaxy_seed = galaxy_seed,
+            ascension = ascension,
+            guild = guild,
+            xpos = xpos,
+            ypos = ypos,
+            system = system,
+            in_nebula = in_nebula
+        )
+
+        if load_data:
+            out.load_system_data(json_interface, guild, True)
+        
+        return out
+
+
+    #####################################################
+    # If it's not in the database, generate it.
+
     position_data = generation.galaxy_single(
         galaxy_seed = galaxy_seed,
         x = xpos,
@@ -1378,6 +1634,9 @@ def get_galaxy_coordinate(
         system = is_system,
         in_nebula = in_nebula
     )
+    
+    # Save the new data.
+    out.save_to_database(json_interface)
 
     if not is_system:
         return out

--- a/bread/space.py
+++ b/bread/space.py
@@ -1730,13 +1730,13 @@ def get_planet_modifiers(
         ) # type: GalaxyTile
 
         if galaxy_tile.in_nebula:
-            denominator = 2.5
+            denominator = 1
         else:
             denominator = math.tau
 
         if galaxy_tile.star.star_type == "black_hole":
-            # If it's a black hole, make it a little crazier by dividing the denominator by 2.
-            denominator /= 2
+            # If it's a black hole, make it a little crazier by dividing the denominator by 5.
+            denominator /= 5
 
         deviation = (1 - tile.planet_deviation) / denominator
 

--- a/bread/space.py
+++ b/bread/space.py
@@ -1913,7 +1913,9 @@ def create_trade_hub(
         "project_progress": {
             "project_1": {},
             "project_2": {},
-            "project_3": {}
+            "project_3": {},
+            "project_4": {},
+            "project_5": {}
         }
     }
 

--- a/bread/space.py
+++ b/bread/space.py
@@ -988,6 +988,15 @@ def get_corruption_chance(
     # where `d` is the distance to (0, 0).
     return ((dist ** 2.15703654359 / 1000) + 118 * math.e ** (-0.232232152965 * (dist / 22.5) ** 2) - 19) / 100
 
+def get_anarchy_corruption_chance(
+        xpos: int,
+        ypos: int
+    ) -> float:
+    """Returns the chance of an anarchy piece becoming corrupted for any point in the galaxy. Between 0 and 1."""
+    regular = get_corruption_chance(xpos, ypos)
+
+    return (regular ** 2) / 1.9602
+
             
 
         

--- a/bread/store.py
+++ b/bread/store.py
@@ -2007,8 +2007,8 @@ class Engine_Efficiency(Space_Shop_Item):
         
         return True
     
-class Project_Credit_Bonus(Space_Shop_Item):
-    name = "project_credit_bonus"
+class Payment_Bonus(Space_Shop_Item):
+    name = "payment_bonus"
     display_name = "Payment Bonus"
 
     @classmethod
@@ -2019,14 +2019,26 @@ class Project_Credit_Bonus(Space_Shop_Item):
         bread = 1000 + 100 * level
         corrupted_bread = 500 + 50 * level
         chessatrons = 150 + 75 * level
-        blue_gems = 2000 + 250 * level
+
+        gems = {
+            values.gem_green.text: 1,
+            values.gem_purple.text: 2,
+            values.gem_blue.text: 4,
+            values.gem_red.text: 8,
+        }
+
+        gem_amount = 500 + 100 * level
+
+        specific_gem = random.Random(f"{user_account.get('id')}-{user_account.get_prestige_level()}-{level}").choice(list(gems.keys()))
+
+        print(f"Random seed: {user_account.get('id')}-{user_account.get_prestige_level()}-{level}")
 
         return [
             ("total_dough", dough),
             (values.normal_bread.text, bread),
             (values.corrupted_bread.text, corrupted_bread),
             (values.chessatron.text, chessatrons),
-            (values.gem_blue.text, blue_gems)
+            (specific_gem, gems[specific_gem] * gem_amount)
         ]
     
     @classmethod
@@ -2083,7 +2095,7 @@ class Project_Credit_Bonus(Space_Shop_Item):
         super().do_purchase(user_account)
         return f"Through some shady business practices you have gotten another {values.project_credits.text} bonus!\nThis is bonus number {user_account.get(cls.name)} for you, your {values.project_credits.text} will be available tomorrow."
 
-space_shop_items = [Bread_Rocket, Upgraded_Autopilot, Fuel_Tank, Fuel_Research, Upgraded_Telescopes, Multiroller_Terminal, Advanced_Exploration, Engine_Efficiency, Project_Credit_Bonus]
+space_shop_items = [Bread_Rocket, Upgraded_Autopilot, Fuel_Tank, Fuel_Research, Upgraded_Telescopes, Multiroller_Terminal, Advanced_Exploration, Engine_Efficiency, Payment_Bonus]
 
 
 

--- a/bread/store.py
+++ b/bread/store.py
@@ -2029,9 +2029,7 @@ class Payment_Bonus(Space_Shop_Item):
 
         gem_amount = 500 + 100 * level
 
-        specific_gem = random.Random(f"{user_account.get('id')}-{user_account.get_prestige_level()}-{level}").choice(list(gems.keys()))
-
-        print(f"Random seed: {user_account.get('id')}-{user_account.get_prestige_level()}-{level}")
+        specific_gem = random.Random(f"{user_account.get_prestige_level()}-{level}").choice(list(gems.keys()))
 
         return [
             ("total_dough", dough),

--- a/bread/store.py
+++ b/bread/store.py
@@ -1378,7 +1378,6 @@ class First_Catch(Prestige_Store_Item):
 class Fuel_Refinement(Prestige_Store_Item):
     name = "fuel_refinement"
     display_name = "Fuel Refinement"
-    aliases = ["fr"]
 
     costs = [0, 1, 1, 1, 1, 2, 2, 2, 2]
 
@@ -1425,7 +1424,7 @@ class Corruption_Negation(Prestige_Store_Item):
     @classmethod
     def description(cls, user_account: account.Bread_Account) -> str:
         level = user_account.get(cls.name) + 1
-        return f"Decreases the amount of corrupted loaves by 10%, to {100 - (level * 10)}% of base."
+        return f"Decreases the chance of non-anarchy piece loaves from being corrupted by 10%, to {100 - (level * 10)}% of base."
 
     @classmethod
     def max_level(cls, user_account: account.Bread_Account = None) -> typing.Optional[int]:
@@ -1433,8 +1432,8 @@ class Corruption_Negation(Prestige_Store_Item):
     
     @classmethod
     def can_be_purchased(cls, user_account: account.Bread_Account) -> bool:
-        # If the space level is less than 4 (which unlocks galaxy travel) then don't allow this to be purchased.
-        if user_account.get_space_level() < 4:
+        # If the space level is less than 3 (which unlocks galaxy travel) then don't allow this to be purchased.
+        if user_account.get_space_level() < 3:
             return False
         
         return super().can_be_purchased(user_account)

--- a/bread/store.py
+++ b/bread/store.py
@@ -1596,7 +1596,7 @@ class Bread_Rocket(Space_Shop_Item):
         
         # (a1 locked) Tier 1: Access to space, Multiroller Terminal (all), Fuel Tank (all)
         #             Tier 2: Advanced Exploration (all), Fuel Research 1, Upgraded Telescopes 1, Engine Efficiency 1
-        # (a2 locked) Tier 3: Upgraded Autopilot 1 (Galaxy travel), Fuel Research 2
+        # (a2 locked) Tier 3: Upgraded Autopilot 1 (Galaxy travel), Fuel Research 2, Payment Bonus (all)
         #             Tier 4: Engine Efficiency 2, Fuel Research 3, Upgraded Telescopes 2
         # (a3 locked) Tier 5: Upgraded Autopilot 2 (Nebula travel), Upgraded Telescopes 3
         #             Tier 6: Engine Efficiency 3, Fuel Research 4, Upgraded Telescopes 4
@@ -1611,7 +1611,7 @@ class Bread_Rocket(Space_Shop_Item):
             # Tier 2.
             f"upgrade your telescopes, advance your exploration, research new methods of creating {values.fuel.text}, and use your fuel more efficiently.",
             # Tier 3.
-            f"traverse through the galaxy and research new methods of creating {values.fuel.text}.",
+            f"traverse through the galaxy, research new methods of creating {values.fuel.text}, and make suspicious deals to obtain more {values.project_credits.text}.",
             # Tier 4.
             f"use your fuel more efficiently, research new methods of creating {values.fuel.text}, and upgrade your telescopes",
             # Tier 5.
@@ -1664,7 +1664,7 @@ class Bread_Rocket(Space_Shop_Item):
             # Tier 2.
             "The Upgraded Telescopes, Advanced Exploration, Fuel Research, and Engine Efficiency shop items have been added to the Space Shop.",
             # Tier 3.
-            "The Upgraded Autopilot and second tier of Fuel Research shop items have been added to the Space Shop.",
+            "The Upgraded Autopilot, Payment Bonus, and second tier of Fuel Research shop items have been added to the Space Shop.",
             # Tier 4.
             "The third tier of Fuel Research and second tier of Upgraded Telescopes and Engine Efficiency are now available to purchase.",
             # Tier 5.
@@ -2053,7 +2053,7 @@ class Payment_Bonus(Space_Shop_Item):
         
         space_level = user_account.get_space_level()
 
-        if space_level <= 4: # Tier 5.
+        if space_level <= 2: # Tier 3.
             return False
         
         required_projects = (user_account.get(cls.name) + 1) * 10 + 10
@@ -2078,7 +2078,7 @@ class Payment_Bonus(Space_Shop_Item):
         ) -> str | None:
         space_level = user_account.get_space_level()
 
-        if space_level <= 4:
+        if space_level <= 2:
             return None # If the rocket level hasn't been reached don't list it at all.
         
         required_projects = (user_account.get(cls.name) + 1) * 10 + 10

--- a/bread/store.py
+++ b/bread/store.py
@@ -2399,7 +2399,7 @@ class Gambit_Shop_Anarchy_Black_Pawn(Gambit_shop_Item):
     display_name = "En Passant"
     level_required = 5
     boost_item = values.anarchy_black_pawn
-    boost_amount = 900
+    boost_amount = 9_000_000
     raw_cost = [(values.anarchy_black_pawn.text, 50), (values.black_pawn.text, 250), (values.gem_purple.text, 50)]
 
     @classmethod
@@ -2411,7 +2411,7 @@ class Gambit_Shop_Anarchy_Black_Knight(Gambit_shop_Item):
     display_name = "Knight Boost"
     level_required = 5
     boost_item = values.anarchy_black_knight
-    boost_amount = 18000
+    boost_amount = 9_000_000
     raw_cost = [(values.anarchy_black_pawn.text, 50), (values.anarchy_black_knight.text, 25), (values.black_knight.text, 250), (values.gem_purple.text, 50)]
 
 class Gambit_Shop_Anarchy_Black_Bishop(Gambit_shop_Item):
@@ -2419,7 +2419,7 @@ class Gambit_Shop_Anarchy_Black_Bishop(Gambit_shop_Item):
     display_name = "Il Vaticano"
     level_required = 5
     boost_item = values.anarchy_black_bishop
-    boost_amount = 18000
+    boost_amount = 9_000_000
     raw_cost = [(values.anarchy_black_pawn.text, 50), (values.anarchy_black_bishop.text, 25), (values.black_bishop.text, 250), (values.gem_purple.text, 50)]
 
 class Gambit_Shop_Anarchy_Black_Rook(Gambit_shop_Item):
@@ -2427,7 +2427,7 @@ class Gambit_Shop_Anarchy_Black_Rook(Gambit_shop_Item):
     display_name = "Siberian Swipe"
     level_required = 5
     boost_item = values.anarchy_black_rook
-    boost_amount = 18000
+    boost_amount = 9_000_000
     raw_cost = [(values.anarchy_black_pawn.text, 50), (values.anarchy_black_rook.text, 25), (values.black_rook.text, 250), (values.gem_purple.text, 50)]
 
 class Gambit_Shop_Anarchy_Black_Queen(Gambit_shop_Item):
@@ -2435,7 +2435,7 @@ class Gambit_Shop_Anarchy_Black_Queen(Gambit_shop_Item):
     display_name = "Radioactive Beta Decay"
     level_required = 5
     boost_item = values.anarchy_black_queen
-    boost_amount = 18000
+    boost_amount = 9_000_000
     raw_cost = [(values.anarchy_black_pawn.text, 50), (values.anarchy_black_queen.text, 25), (values.black_queen.text, 250), (values.gem_purple.text, 50)]
 
 class Gambit_Shop_Anarchy_Black_King(Gambit_shop_Item):
@@ -2443,7 +2443,7 @@ class Gambit_Shop_Anarchy_Black_King(Gambit_shop_Item):
     display_name = "La Bastarda"
     level_required = 5
     boost_item = values.anarchy_black_king
-    boost_amount = 18000
+    boost_amount = 9_000_000
     raw_cost = [(values.anarchy_black_pawn.text, 50), (values.anarchy_black_king.text, 25), (values.black_king.text, 250), (values.gem_purple.text, 50)]
 
 ##########################################################################################
@@ -2453,7 +2453,7 @@ class Gambit_Shop_Anarchy_White_Pawn(Gambit_shop_Item):
     display_name = "Knook Promotion"
     level_required = 6
     boost_item = values.anarchy_white_pawn
-    boost_amount = 36000
+    boost_amount = 18_000_000
     raw_cost = [(values.anarchy_white_pawn.text, 50), (values.white_pawn.text, 250), (values.gem_green.text, 50)]
 
 class Gambit_Shop_Anarchy_White_Knight(Gambit_shop_Item):
@@ -2461,7 +2461,7 @@ class Gambit_Shop_Anarchy_White_Knight(Gambit_shop_Item):
     display_name = "Anti-Queen"
     level_required = 6
     boost_item = values.anarchy_white_knight
-    boost_amount = 36000
+    boost_amount = 18_000_000
     raw_cost = [(values.anarchy_white_pawn.text, 50), (values.anarchy_white_knight.text, 25), (values.white_knight.text, 250), (values.gem_green.text, 50)]
 
 class Gambit_Shop_Anarchy_White_Bishop(Gambit_shop_Item):
@@ -2469,7 +2469,7 @@ class Gambit_Shop_Anarchy_White_Bishop(Gambit_shop_Item):
     display_name = "Vacation Home"
     level_required = 6
     boost_item = values.anarchy_white_bishop
-    boost_amount = 36000
+    boost_amount = 18_000_000
     raw_cost = [(values.anarchy_white_pawn.text, 50), (values.anarchy_white_bishop.text, 25), (values.white_bishop.text, 250), (values.gem_green.text, 50)]
 
 class Gambit_Shop_Anarchy_White_Rook(Gambit_shop_Item):
@@ -2477,7 +2477,7 @@ class Gambit_Shop_Anarchy_White_Rook(Gambit_shop_Item):
     display_name = "Vertical Castling"
     level_required = 6
     boost_item = values.anarchy_white_rook
-    boost_amount = 36000
+    boost_amount = 18_000_000
     raw_cost = [(values.anarchy_white_pawn.text, 50), (values.anarchy_white_rook.text, 25), (values.white_rook.text, 250), (values.gem_green.text, 50)]
 
 class Gambit_Shop_Anarchy_White_Queen(Gambit_shop_Item):
@@ -2485,7 +2485,7 @@ class Gambit_Shop_Anarchy_White_Queen(Gambit_shop_Item):
     display_name = "Botez Gambit"
     level_required = 6
     boost_item = values.anarchy_white_queen
-    boost_amount = 36000
+    boost_amount = 18_000_000
     raw_cost = [(values.anarchy_white_pawn.text, 50), (values.anarchy_white_queen.text, 25), (values.white_queen.text, 250), (values.gem_green.text, 50)]
 
 class Gambit_Shop_Anarchy_White_King(Gambit_shop_Item):
@@ -2493,7 +2493,7 @@ class Gambit_Shop_Anarchy_White_King(Gambit_shop_Item):
     display_name = "Double Bongcloud"
     level_required = 6
     boost_item = values.anarchy_white_king
-    boost_amount = 36000
+    boost_amount = 18_000_000
     raw_cost = [(values.anarchy_white_pawn.text, 50), (values.anarchy_white_king.text, 25), (values.white_king.text, 250), (values.gem_green.text, 50)]
 
 ##########################################################################################

--- a/bread/utility.py
+++ b/bread/utility.py
@@ -52,13 +52,14 @@ def write_number_of_times(number: int) -> str:
 
 def write_count(
         number: int,
-        word: str
+        word: str,
+        delimiter: str = ""
     ) -> str:
     """Writes the count of a number and word, and will pluralize the word if the number is not 1."""
     if number == 1:
         pass
     else:
-        word =  word + "s"
+        word =  word + delimiter + "s"
     output = smart_number(number) + " " + word
     return output
 

--- a/bread/values.py
+++ b/bread/values.py
@@ -552,9 +552,9 @@ class Anarchy_Piece_Emote(Emote):
         self.text = text
         self.name = name
         if isWhite:
-            self.value = 36000
+            self.value = 360_000
         else:
-            self.value = 18000
+            self.value = 180_000
         self.attributes = ["anarchy_pieces"]
         self.awards_value = False
         self.alchemy_value = self.value

--- a/bread_cog.py
+++ b/bread_cog.py
@@ -1480,14 +1480,14 @@ class Bread_cog(commands.Cog, name="Bread"):
             output_3 += f"You have {user_account.write_count('special_bread', 'Special Bread')}.\n"
         
         if len(output) + len(output_2) + len(output_3) < 1900:
-            await utility.smart_reply(ctx, output + output_2 + output_3)
+            await ctx.reply(output + output_2 + output_3)
         elif len(output) + len(output_2) < 1900:
-            await utility.smart_reply(ctx, output + output_2)
-            await utility.smart_reply(ctx, "Stats continued:\n" + output_3)
+            await ctx.reply(output + output_2)
+            await ctx.reply("Stats continued:\n" + output_3)
         else:
-            await utility.smart_reply(ctx, output)
-            await utility.smart_reply(ctx, "Stats continued:\n" + output_2)
-            await utility.smart_reply(ctx, "Stats continued:\n" + output_3)
+            await ctx.reply(output)
+            await ctx.reply("Stats continued:\n" + output_2)
+            await ctx.reply("Stats continued:\n" + output_3)
         # await ctx.reply(output)
 
         #await self.do_chessboard_completion(ctx)
@@ -2169,11 +2169,11 @@ loaf_converter""",
             
         # check if black hole is activated and if we're in #bread-rolls
         if user_account.get("black_hole") == 2 and get_channel_permission_level(ctx) == PERMISSION_LEVEL_MAX:
-            await utility.smart_reply(ctx, ":cyclone:")
+            await ctx.reply(":cyclone:")
         
         # black hole is not activated, send messages normally
         for roll in output_messages:
-            await utility.smart_reply(ctx, roll)
+            await ctx.reply(roll)
             if len(output_messages) > 1:
                 await asyncio.sleep(.75)
                 
@@ -2215,7 +2215,7 @@ loaf_converter""",
                         messages.append("\n".join(add))
                 
                 for message in messages:
-                    await utility.smart_reply(ctx, message)
+                    await ctx.reply(message)
                 
         except:
             print(traceback.format_exc())
@@ -2296,45 +2296,45 @@ loaf_converter""",
         elif user_account.get("full_chess_set") <= 5:
             messages_to_send = trons_to_make
             while messages_to_send > 0:
-                await utility.smart_reply(ctx, f"You have collected all the chess pieces! Congratulations!\n\nWhat a beautiful collection!")
+                await ctx.reply(f"You have collected all the chess pieces! Congratulations!\n\nWhat a beautiful collection!")
                 await asyncio.sleep(1)
 
-                await utility.smart_reply(ctx, f"{board}")
+                await ctx.reply(f"{board}")
                 await asyncio.sleep(1)
 
-                await utility.smart_reply(ctx, f"You will now be awarded the most prestigious of chess pieces: The Mega Chessatron!")
+                await ctx.reply(f"You will now be awarded the most prestigious of chess pieces: The Mega Chessatron!")
                 await asyncio.sleep(1)
 
-                await utility.smart_reply(ctx, f"{values.chessatron.text}")
+                await ctx.reply(f"{values.chessatron.text}")
                 await asyncio.sleep(1)
-                await utility.smart_reply(ctx, f"May it serve you well. You also have been awarded **{utility.smart_number(total_dough_value//trons_to_make)} dough** for your efforts.")
+                await ctx.reply(f"May it serve you well. You also have been awarded **{utility.smart_number(total_dough_value//trons_to_make)} dough** for your efforts.")
                 messages_to_send -= 1
         elif trons_to_make < 10:
             messages_to_send = trons_to_make
             while messages_to_send > 0:
                 await asyncio.sleep(1)
-                await utility.smart_reply(ctx, f"Congratulations! You've collected all the chess pieces! This will be chessatron **#{utility.smart_number(user_account.get('full_chess_set')+1-messages_to_send)}** for you.\n\n{board}\nHere is your award of **{utility.smart_number(total_dough_value//trons_to_make)} dough**, and here's your new chessatron!")
+                await ctx.reply(f"Congratulations! You've collected all the chess pieces! This will be chessatron **#{utility.smart_number(user_account.get('full_chess_set')+1-messages_to_send)}** for you.\n\n{board}\nHere is your award of **{utility.smart_number(total_dough_value//trons_to_make)} dough**, and here's your new chessatron!")
                 await asyncio.sleep(1)
-                await utility.smart_reply(ctx, f"{values.chessatron.text}")
+                await ctx.reply(f"{values.chessatron.text}")
                 messages_to_send -= 1
         elif trons_to_make < 5000:
             output = f"Congratulations! More chessatrons! You've made {utility.smart_number(user_account.get('full_chess_set'))} of them in total and {utility.smart_number(trons_to_make)} right now! Here's your reward of **{utility.smart_number(total_dough_value)} dough**."
-            await utility.smart_reply(ctx, output)
+            await ctx.reply(output)
             await asyncio.sleep(1)
             
             output = ""
             for _ in range(trons_to_make):
                 output += f"{values.chessatron.text} "
                 if len(output) > 1800:
-                    await utility.smart_reply(ctx, output)
+                    await ctx.reply(output)
                     output = ""
                     await asyncio.sleep(1)
-            await utility.smart_reply(ctx, output)
+            await ctx.reply(output)
         else:
             output = f"Wow. You have created a **lot** of chessatrons. {utility.smart_number(trons_to_make)} to be exact. I will not even attempt to list them all. Here is your reward of **{utility.smart_number(total_dough_value)} dough**."
-            await utility.smart_reply(ctx, output)
+            await ctx.reply(output)
             await asyncio.sleep(1)
-            await utility.smart_reply(ctx, f"{values.chessatron.text} x {utility.smart_number(trons_to_make)}")
+            await ctx.reply(f"{values.chessatron.text} x {utility.smart_number(trons_to_make)}")
 
     
 
@@ -2361,14 +2361,14 @@ loaf_converter""",
         if arg.lower() == "on":
             user_account.set("auto_chessatron", True)
             self.json_interface.set_account(ctx.author, user_account, guild = ctx.guild.id)
-            await utility.smart_reply(ctx, f"Auto chessatron is now on.")
+            await ctx.reply(f"Auto chessatron is now on.")
         elif arg.lower() == "off":
             user_account.set("auto_chessatron", False)
             self.json_interface.set_account(ctx.author, user_account, guild = ctx.guild.id)
-            await utility.smart_reply(ctx, f"Auto chessatron is now off.")
+            await ctx.reply(f"Auto chessatron is now off.")
         else:
             if get_channel_permission_level(ctx) < PERMISSION_LEVEL_ACTIVITIES:
-                await utility.smart_reply(ctx, f"Thank you for your interest in creating chessatrons! You can do so over in {self.json_interface.get_rolling_channel(ctx.guild.id)}.")
+                await ctx.reply(f"Thank you for your interest in creating chessatrons! You can do so over in {self.json_interface.get_rolling_channel(ctx.guild.id)}.")
                 return
             
             if is_numeric(arg):
@@ -2427,7 +2427,7 @@ loaf_converter""",
                 break
         
         if number_of_chessatrons is not None and number_of_chessatrons < 0:
-            await utility.smart_reply(ctx, "You can't make a negative number of chessatrons.")
+            await ctx.reply("You can't make a negative number of chessatrons.")
             return
         
 
@@ -2463,7 +2463,7 @@ loaf_converter""",
         # gem_count = user_account.get(values.gem_red.text)
 
         if total_gem_count < 32 or number_of_chessatrons == 0:
-            await utility.smart_reply(ctx, f"You need at least 32 gems to create a chessatron.")
+            await ctx.reply(f"You need at least 32 gems to create a chessatron.")
             return
 
         gems_needed = number_of_chessatrons * 32
@@ -2514,7 +2514,7 @@ loaf_converter""",
             gold_gems -= gold_gems_used
 
         if gems_needed > 0:
-            await utility.smart_reply(ctx, "It seems something went wrong.")
+            await ctx.reply("It seems something went wrong.")
             return
 
         if gold_gems // 4 != gold_gems / 4:
@@ -2570,7 +2570,7 @@ loaf_converter""",
 
         gems_string = ", ".join(gems_list)
 
-        await utility.smart_reply(ctx, f"You have used {gems_string} to make chess pieces.")
+        await ctx.reply(f"You have used {gems_string} to make chess pieces.")
 
         await self.do_chessboard_completion(ctx, amount = parse_int(number_of_chessatrons))
 
@@ -2598,16 +2598,16 @@ loaf_converter""",
         
         if toggle.lower() == "on":
             user_account.set("spellcheck", True)
-            await utility.smart_reply(ctx, f"Spellcheck is now on.")
+            await ctx.reply(f"Spellcheck is now on.")
         elif toggle.lower() == "off":
             user_account.set("spellcheck", False)
-            await utility.smart_reply(ctx, f"Spellcheck is now off.")
+            await ctx.reply(f"Spellcheck is now off.")
         else:
             user_account.set("spellcheck", not user_account.get("spellcheck"))
             if user_account.get("spellcheck"):
-                await utility.smart_reply(ctx, f"Spellcheck is now on.")
+                await ctx.reply(f"Spellcheck is now on.")
             else:
-                await utility.smart_reply(ctx, f"Spellcheck is now off.")
+                await ctx.reply(f"Spellcheck is now off.")
 
         self.json_interface.set_account(ctx.author, user_account, guild = ctx.guild.id)
 
@@ -2678,14 +2678,14 @@ loaf_converter""",
 
         description += """If you would like to ascend, please type "I would like to ascend".\nIf you would like to ascend to the highest available ascension, please type "Take me to the latest ascension".\nRemember that this is a permanent action that cannot be undone."""
 
-        await utility.smart_reply(ctx, description)
+        await ctx.reply(description)
 
         def check(m: discord.Message):  # m = discord.Message.
             return m.author.id == ctx.author.id and m.channel.id == ctx.channel.id 
         try:
             msg = await self.bot.wait_for('message', check = check, timeout = 60.0)
         except asyncio.TimeoutError: 
-            await utility.smart_reply(ctx, "If you are not ready yet, that is okay.")
+            await ctx.reply("If you are not ready yet, that is okay.")
             return 
         
         response = msg.content
@@ -2693,7 +2693,7 @@ loaf_converter""",
         latest_ascension_msg = "take me to the latest ascension" in response.lower()
 
         if next_ascension_msg and latest_ascension_msg:
-            await utility.smart_reply(ctx, "Contradictory messages, I see. Please come back when you are feeling more decisive.")
+            await ctx.reply("Contradictory messages, I see. Please come back when you are feeling more decisive.")
             return
         elif next_ascension_msg:
             # now we can ascend
@@ -2702,7 +2702,7 @@ loaf_converter""",
 
             description = f"Congratulations! You have ascended to a higher plane of existence. You are now at level {user_account.get_prestige_level()} of ascension. I wish you the best of luck on your journey!\n\n"
             description += f"You have also recieved **1 {values.ascension_token.text}**. You will recieve more as you get more daily rolls. You can spend it at the hidden bakery to buy special upgrades. Find it with \"$bread hidden_bakery\"."
-            await utility.smart_reply(ctx, description)
+            await ctx.reply(description)
         elif latest_ascension_msg:
             pre_ascension_tokens = user_account.get(values.ascension_token.text)
             user_account.increase_prestige_to_goal(max_prestige_level)
@@ -2710,9 +2710,9 @@ loaf_converter""",
 
             description = f"Congratulations! You have ascended to the highest plane of existence. You are now at level {user_account.get_prestige_level()} of ascension. I wish you the best of luck on your journey!\n\n"
             description += f"You have also recieved **{post_ascension_tokens - pre_ascension_tokens} {values.ascension_token.text}**. You will recieve more as you get more daily rolls. You can spend it at the hidden bakery to buy special upgrades. Find it with \"$bread hidden_bakery\"."
-            await utility.smart_reply(ctx, description)
+            await ctx.reply(description)
         else:
-            await utility.smart_reply(ctx, "If you are not ready yet, that is okay.")
+            await ctx.reply("If you are not ready yet, that is okay.")
             return 
 
         # and save the account
@@ -2847,11 +2847,11 @@ loaf_converter""",
         for item in items:
             addition = f"\t**{item.display_name}** - {item.get_price_description(user_account)}\n{item.description(user_account)}\n\n"
             if len(output) + len(addition) > 1800:
-                await utility.smart_reply(ctx, output)
+                await ctx.reply(output)
                 output = "Shop Continued:\n\n"
             output += addition
             # if len(output) > 1800:
-            #     await utility.smart_reply(ctx, output)
+            #     await ctx.reply(output)
             #     output = "Shop Continued:\n\n"
         
         if len(items) == 0:
@@ -2859,7 +2859,7 @@ loaf_converter""",
         else:
             output += 'To buy an item, just type "$bread buy [item name]".'
 
-        await utility.smart_reply(ctx, output)
+        await ctx.reply(output)
         return
 
     ########################################################################################################################
@@ -2877,13 +2877,13 @@ loaf_converter""",
             ):
 
         if item_name is None:
-            await utility.smart_reply(ctx, "Please specify an item to buy.")
+            await ctx.reply("Please specify an item to buy.")
             return
 
         # first we make sure this is a valid channel
         #if ctx.channel.name not in earnable_channels:
         if get_channel_permission_level(ctx) < PERMISSION_LEVEL_ACTIVITIES:
-            await utility.smart_reply(ctx, f"Thank you for your interest in purchasing an item from the store. Please visit our nearby location in {self.json_interface.get_rolling_channel(ctx.guild.id)}.")
+            await ctx.reply(f"Thank you for your interest in purchasing an item from the store. Please visit our nearby location in {self.json_interface.get_rolling_channel(ctx.guild.id)}.")
             return
 
         # split the first word of the item name and check if it's a number
@@ -2891,7 +2891,7 @@ loaf_converter""",
         item_name_split = item_name.split(" ")
         if len(item_name_split) > 1:
             if item_name_split[0][0] == '-':
-                await utility.smart_reply(ctx, "You can't buy negative numbers of items.")
+                await ctx.reply("You can't buy negative numbers of items.")
                 return
             if is_digit(item_name_split[0]):
                 item_name = " ".join(item_name_split[1:])
@@ -2907,7 +2907,7 @@ loaf_converter""",
             item_name_2 = item_name
 
         if item_count < 1:
-            await utility.smart_reply(ctx, "You can't buy zero of an item.")
+            await ctx.reply("You can't buy zero of an item.")
             return
 
         # first we get the account of the user who called it
@@ -2941,7 +2941,7 @@ loaf_converter""",
                 item = i
                 break
         else: # if the for loop doesn't break, run this. This should run the same as an 'if item is None' check.
-            await utility.smart_reply(ctx, "Sorry, but I don't recognize that item's name.")
+            await ctx.reply("Sorry, but I don't recognize that item's name.")
             return
 
 
@@ -2976,12 +2976,12 @@ loaf_converter""",
             # if it exists but can't be bought, we say so
             if item not in buyable_items:
                 # removed item is None check, as item will never be None. see above.
-                await utility.smart_reply(ctx, "Sorry, but you've already purchased as many of that as you can.")
+                await ctx.reply("Sorry, but you've already purchased as many of that as you can.")
                 return
             
             try:
                 if item.find_max_purchasable_count(user_account) <= 0:
-                    await utility.smart_reply(ctx, "Sorry, but you've already purchased as many of that as you can.")
+                    await ctx.reply("Sorry, but you've already purchased as many of that as you can.")
                     return
             except AttributeError:
                 # If an AttributeError was thrown the shop item probably doesn't have find_max_purchasable_count and we can ignore it.
@@ -2990,7 +2990,7 @@ loaf_converter""",
 
             # now we check if the user has enough dough
             if not item.is_affordable_for(user_account):
-                await utility.smart_reply(ctx, "Sorry, but you can't afford to buy that.")
+                await ctx.reply("Sorry, but you can't afford to buy that.")
                 return
 
             # now we actually purchase the item
@@ -3022,7 +3022,7 @@ loaf_converter""",
                 cost_text += " remaining."
 
             if item in store.prestige_store_items:
-                #await utility.smart_reply(ctx, f"Congratulations! You've unlocked the **{item.display_name}**! {text}")
+                #await ctx.reply(f"Congratulations! You've unlocked the **{item.display_name}**! {text}")
                 if text is None:
                     text = f"Congratulations! You've unlocked the **{item.display_name}** upgrade! You are now at level {user_account.get(item.name)}."
                 
@@ -3036,7 +3036,7 @@ loaf_converter""",
 
             text += "\n\n" + cost_text
 
-            await utility.smart_reply(ctx, text)
+            await ctx.reply(text)
 
         else: # item count above 1
 
@@ -3101,7 +3101,7 @@ loaf_converter""",
 
             text += "\n\n" + cost_text
 
-            await utility.smart_reply(ctx, text)
+            await ctx.reply(text)
 
 
         # complete chessatron on this command
@@ -3354,9 +3354,9 @@ For example, "$bread gift Melodie all chess_pieces" would gift all your chess pi
                     await asyncio.sleep(1)
                 
             if gifted_count > 0:
-                await utility.smart_reply(ctx, f"Gifted {utility.smart_number(gifted_count)} {emoji} to {receiver_account.get_display_name()}.")
+                await ctx.reply(f"Gifted {utility.smart_number(gifted_count)} {emoji} to {receiver_account.get_display_name()}.")
             else:
-                await utility.smart_reply(ctx, f"Sorry, you don't have any {emoji} to gift.")
+                await ctx.reply(f"Sorry, you don't have any {emoji} to gift.")
 
             return        
 
@@ -3655,7 +3655,7 @@ anarchy - 1000% of your wager.
                     # grid[i][k] = random.choice(gamble.reward_values).text
         try:  #sometimes we'll get a timeout error and the function will crash, this should allow
               # the user to be removed from the currently_interacting list
-            message = await utility.smart_reply(ctx, self.show_grid(grid))
+            message = await ctx.reply(self.show_grid(grid))
             await asyncio.sleep(2)
 
 
@@ -3683,28 +3683,28 @@ anarchy - 1000% of your wager.
             pass
         try: #try block because of potential messsage deletion.
             if result['result'].name == "horsey":
-                await utility.smart_reply(ctx, "Sorry, you didn't win anything. Better luck next time.")
+                await ctx.reply("Sorry, you didn't win anything. Better luck next time.")
             elif result['result'].name in ["brick", "fide_brick", "brick_fide", "brick_gold"]:
                 try: # brick avoidance deterrant
                     response = "You found a brick. Please hold, delivering reward at high speed."
                     if result['result'].name == "brick_gold":
                         response += f" Looks like you'll be able to sell this one for {utility.smart_number(winnings)} dough."
-                    await utility.smart_reply(ctx, response)
+                    await ctx.reply(response)
                     await asyncio.sleep(2)
                 except:
                     pass 
                 await ctx.invoke(self.bot.get_command('brick'), member=ctx.author)
             else:
-                await utility.smart_reply(ctx, f"With a {winning_text}, you won {utility.smart_number(winnings)} dough.")
+                await ctx.reply(f"With a {winning_text}, you won {utility.smart_number(winnings)} dough.")
         
             daily_gambles = user_account.get_value_strict("daily_gambles")
             if daily_gambles == max_gambles:
-                await utility.smart_reply(ctx, "That was all the gambling you can do today.")
+                await ctx.reply("That was all the gambling you can do today.")
 
             elif daily_gambles >= max_gambles-3:
                 #await ctx.reply("You can gamble one more time today.")
                 text= "You can gamble "+Bread_cog.write_number_of_times(max_gambles-daily_gambles)+" more today."
-                await utility.smart_reply(ctx, text)
+                await ctx.reply(text)
         except:
             pass #only happens if original message was deleted.
 
@@ -4573,19 +4573,19 @@ anarchy - 1000% of your wager.
         if count is None:
             count = 1
         if count == 0:
-            await utility.smart_reply(ctx, "Alright, I have made zero of those for you...")
+            await ctx.reply("Alright, I have made zero of those for you...")
             return
         if count < 0:
-            await utility.smart_reply(ctx, "The laws of alchemy prevent me from utilizing negative energy.")
+            await ctx.reply("The laws of alchemy prevent me from utilizing negative energy.")
             return
         if count > 1000000000000000:
-            await utility.smart_reply(ctx, "That is an unreasonable number of items to alchemize. Please try again with a smaller number.")
+            await ctx.reply("That is an unreasonable number of items to alchemize. Please try again with a smaller number.")
             return
 
         # print(f"{ctx.author.name} requested to alchemize {count} {target_item}.")
 
         if get_channel_permission_level(ctx) < PERMISSION_LEVEL_ACTIVITIES:
-            await utility.smart_reply(ctx, f"Thank you for your interest in bread alchemy. Please find the alchemical circle is present in {self.json_interface.get_rolling_channel(ctx.guild.id)}.")
+            await ctx.reply(f"Thank you for your interest in bread alchemy. Please find the alchemical circle is present in {self.json_interface.get_rolling_channel(ctx.guild.id)}.")
             return
 
         #check if they're already alchemizing
@@ -4611,12 +4611,12 @@ anarchy - 1000% of your wager.
             #####      GET ITEM
 
             if (target_item is None):
-                await utility.smart_reply(ctx, "Welcome to the alchemy circle. Please say the item you would like to create.")
+                await ctx.reply("Welcome to the alchemy circle. Please say the item you would like to create.")
                 try:
                     msg = await self.bot.wait_for('message', check = check, timeout = 60.0)
                 except asyncio.TimeoutError: 
                     # at this point, the check didn't become True, let's handle it.
-                    await utility.smart_reply(ctx, f"My patience is limited. Come back when you know what you want.")
+                    await ctx.reply(f"My patience is limited. Come back when you know what you want.")
                     self.remove_from_interacting(ctx.author.id)
                     return
                 target_item = msg.content #values.get_emote(msg.content)
@@ -4628,7 +4628,7 @@ anarchy - 1000% of your wager.
             target_emote = values.get_emote(target_item)
 
             if (target_emote is None):
-                await utility.smart_reply(ctx, f"I do not recognize that item. Please start over.")
+                await ctx.reply(f"I do not recognize that item. Please start over.")
                 self.remove_from_interacting(ctx.author.id)
                 return
 
@@ -4661,11 +4661,11 @@ anarchy - 1000% of your wager.
                                 
                 if len(recipe_list) == 0:
                     # Either the recipe list was initially blank, in which there is some issue, or the user has not unlocked any recipes for the item yet.
-                    await utility.smart_reply(ctx, f"I'm sorry, but your technology has not yet found a way to create {target_emote.text}.")
+                    await ctx.reply(f"I'm sorry, but your technology has not yet found a way to create {target_emote.text}.")
                     self.remove_from_interacting(ctx.author.id)
                     return
             else:
-                await utility.smart_reply(ctx, f"There are no recipes to create {target_emote.text}. Perhaps research has not progressed far enough.")
+                await ctx.reply(f"There are no recipes to create {target_emote.text}. Perhaps research has not progressed far enough.")
                 self.remove_from_interacting(ctx.author.id)
                 return
 
@@ -4707,30 +4707,30 @@ anarchy - 1000% of your wager.
                     recipes_description += f"{ingredient.text}: {user_account.get(ingredient.text)}\n"
             
                 recipes_description += "\nPlease reply with either the number of the recipe you would like to use, or \"cancel\"."
-                await utility.smart_reply(ctx, recipes_description)
+                await ctx.reply(recipes_description)
                 
                 try:
                     msg = await self.bot.wait_for('message', check = check, timeout = 60.0)
                 except asyncio.TimeoutError: 
                     # at this point, the check didn't become True, let's handle it.
-                    await utility.smart_reply(ctx, f"My patience is limited. This offering is rejected.")
+                    await ctx.reply(f"My patience is limited. This offering is rejected.")
                     self.remove_from_interacting(ctx.author.id)
                     return
 
                 if "cancel" in msg.content.lower():
-                    await utility.smart_reply(ctx, "You have cancelled this transaction.")
+                    await ctx.reply("You have cancelled this transaction.")
                     self.remove_from_interacting(ctx.author.id)
                     return
 
                 try:
                     recipe_num = parse_int(msg.content)
                 except ValueError:
-                    await utility.smart_reply(ctx, f"I do not recognize that as a number. Please try again from the beginning.")
+                    await ctx.reply(f"I do not recognize that as a number. Please try again from the beginning.")
                     self.remove_from_interacting(ctx.author.id)
                     return
             
             if recipe_num > len(recipe_list) or recipe_num < 1:
-                await utility.smart_reply(ctx, f"That is not a valid recipe number. Please start over.")
+                await ctx.reply(f"That is not a valid recipe number. Please start over.")
                 self.remove_from_interacting(ctx.author.id)
                 return
 
@@ -4765,12 +4765,12 @@ anarchy - 1000% of your wager.
                     question_text += f"{pair[0].text}: {user_account.get(pair[0].text)} of {pair[1] * count}\n"
                         
                 question_text += "\nWould you like to proceed? Yes or No."
-                await utility.smart_reply(ctx, question_text)
+                await ctx.reply(question_text)
 
                 try:
                     msg = await self.bot.wait_for('message', check = check, timeout = 60.0)
                 except asyncio.TimeoutError:
-                    await utility.smart_reply(ctx, f"My patience is limited. This offering is rejected.")
+                    await ctx.reply(f"My patience is limited. This offering is rejected.")
                     self.remove_from_interacting(ctx.author.id)
                     return
                 
@@ -4779,11 +4779,11 @@ anarchy - 1000% of your wager.
                 if any([i in content for i in ["yes", "y", "confirm"]]):
                     pass
                 elif any([i in content for i in ["no", "n", "deny"]]):
-                    await utility.smart_reply(ctx, "You have rejected this recipe.")
+                    await ctx.reply("You have rejected this recipe.")
                     self.remove_from_interacting(ctx.author.id)
                     return
                 else:
-                    await utility.smart_reply(ctx, "I do not recognize your response. You may come back when you are feeling more decisive.")
+                    await ctx.reply("I do not recognize your response. You may come back when you are feeling more decisive.")
                     self.remove_from_interacting(ctx.author.id)
                     return
 
@@ -4799,7 +4799,7 @@ anarchy - 1000% of your wager.
                 # print(f"{ctx.author.display_name} is attempting to alchemize {count} {target_emote.name}")
                 # print(f"cost is {cost} and posessions is {posessions}")
                 if posessions < cost:
-                    await utility.smart_reply(ctx, f"You do not have enough {pair[0].text} to create {count} {target_emote.text}. This offering is rejected.")
+                    await ctx.reply(f"You do not have enough {pair[0].text} to create {count} {target_emote.text}. This offering is rejected.")
                     self.remove_from_interacting(ctx.author.id)
                     return
             
@@ -4832,7 +4832,7 @@ anarchy - 1000% of your wager.
             if target_emote.gives_alchemy_award() and not override_dough:
                 output += f"\nYou have also been awarded **{utility.smart_number(value)} dough** for your efforts."
 
-            await utility.smart_reply(ctx, output)
+            await ctx.reply(output)
 
             await self.do_chessboard_completion(ctx)
             await self.anarchy_chessatron_completion(ctx)
@@ -5030,14 +5030,14 @@ anarchy - 1000% of your wager.
         formatted_anarchy_pieces = self.format_anarchy_pieces(account.values).strip(" \n")
 
         if len("\n".join(output)) + len(formatted_anarchy_pieces) + 4 > 1900:
-            await utility.smart_reply(ctx, "\n".join(output))
+            await ctx.reply("\n".join(output))
             output = ["Stats continued:"]
 
 
         output.append("") # Add a blank item to add an extra new line.
         output.append(formatted_anarchy_pieces)
 
-        await utility.smart_reply(ctx, "\n".join(output))
+        await ctx.reply("\n".join(output))
 
 
 
@@ -5187,12 +5187,7 @@ anarchy - 1000% of your wager.
         unfortunate_embed.set_image(url=file_path)
         unfortunate_embed.set_footer(text=f"Map generated in {round(after-before, 3)} seconds.")
 
-        try:
-            # We need to copy send_file here because if we don't and this message is unable to send
-            # when it sends it below it won't have the image. I'm not sure why this happens, but it does.
-            return await ctx.reply(content, embed=unfortunate_embed, file=copy.deepcopy(send_file))
-        except discord.HTTPException:
-            return await ctx.send(ctx.author.mention + "\n\n" + str(content), embed=unfortunate_embed, file=send_file)
+        return await ctx.reply(content, embed=unfortunate_embed, file=send_file)
 
 
     @bread.command(
@@ -5231,44 +5226,6 @@ anarchy - 1000% of your wager.
             user_account = user_account,
             content = None # So it includes nothing else in the message.
         )
-        
-        # ###############################
-
-        # map_data = space.space_map(
-        #     account=user_account,
-        #     json_interface = self.json_interface,
-        #     mode=mode
-        # )
-
-        # ###############################
-
-        # corruption_chance = round(user_account.get_corruption_chance(json_interface=self.json_interface) * 100, 2)
-
-        # if mode == "galaxy" or mode == "g":
-        #     prefix = "Galaxy map:"
-        #     middle = f"Your current galaxy location: {user_account.get_galaxy_location(json_interface=self.json_interface)}.\nCorruption chance: {corruption_chance}%."
-        #     suffix = "You can use '$bread space map' to view the map for the system you're in.\n\nUse '$bread space move galaxy' to move around on this map."
-        # else:
-        #     prefix = "System map:"
-        #     middle = f"Your current galaxy location: {user_account.get_galaxy_location(json_interface=self.json_interface)}.\nYour current system location: {user_account.get_system_location()}.\nCorruption chance: {corruption_chance}%."
-        #     suffix = "You can use '$bread space map galaxy' to view the galaxy map.\n\nUse '$bread space move system' to move around on this map.\nUse '$bread space analyze' to get more information about somewhere."
-
-        # send_file = discord.File(map_data, filename="space_map.png")
-        # file_path = "attachment://space_map.png"
-
-        # unfortunate_embed = discord.Embed( # It's unfortunate that we have to use one.
-        #     title = prefix,
-        #     description = middle + "\n\n" + suffix,
-        #     color=8884479,
-        # )
-        # unfortunate_embed.set_image(url=file_path)
-
-        # try:
-        #     # We need to copy send_file here because if we don't and this message is unable to send
-        #     # when it sends it below it won't have the image. I'm not sure why this happens, but it does.
-        #     await ctx.reply(embed=unfortunate_embed, file=copy.deepcopy(send_file))
-        # except discord.HTTPException:
-        #     await ctx.send(ctx.author.mention, embed=unfortunate_embed, file=send_file)
         
     ########################################################################################################################
     #####      BREAD SPACE ANALYZE
@@ -5424,12 +5381,7 @@ anarchy - 1000% of your wager.
         )
         embed_send.set_image(url=file_path)
         
-        try:
-            # We need to copy send_file here because if we don't and this message is unable to send
-            # when it sends it below it won't have the image. I'm not sure why this happens, but it does.
-            await ctx.reply(embed=embed_send, file=copy.deepcopy(send_file))
-        except discord.HTTPException:
-            await ctx.send(ctx.author.mention, embed=embed_send, file=send_file)
+        await ctx.reply(embed=embed_send, file=send_file)
 
 
 
@@ -5735,7 +5687,7 @@ anarchy - 1000% of your wager.
             confirm_text = ["yes", "y", "confirm"]
             cancel_text = ["no", "n", "cancel"]
 
-            await utility.smart_reply(ctx, f"You are contributing {utility.smart_number(amount_contribute)} {item.text} to the {project_name} project.\nThis will require {utility.smart_number(credits_used)} {values.project_credits.text}.\nYou currently have the following:\n- {utility.smart_number(user_account.get(item.text))} {item.text}\n- {utility.smart_number(user_account.get('hub_credits'))} {values.project_credits.text}\nWould you like to go through with your confirmation? Yes or No.")
+            await ctx.reply(f"You are contributing {utility.smart_number(amount_contribute)} {item.text} to the {project_name} project.\nThis will require {utility.smart_number(credits_used)} {values.project_credits.text}.\nYou currently have the following:\n- {utility.smart_number(user_account.get(item.text))} {item.text}\n- {utility.smart_number(user_account.get('hub_credits'))} {values.project_credits.text}\nWould you like to go through with your confirmation? Yes or No.")
                 
             def check(m: discord.Message):
                 return m.author.id == ctx.author.id and m.channel.id == ctx.channel.id 
@@ -5743,17 +5695,17 @@ anarchy - 1000% of your wager.
             try:
                 msg = await self.bot.wait_for('message', check = check, timeout = 60.0)
             except asyncio.TimeoutError: 
-                await utility.smart_reply(ctx, "I'm sorry, but you have taken too long and I must attend to the next customer.")
+                await ctx.reply("I'm sorry, but you have taken too long and I must attend to the next customer.")
                 self.remove_from_interacting(ctx.author.id)
                 return
             
             if msg.content.lower() in cancel_text:
-                await utility.smart_reply(ctx, "Very well, come back when you would like to contribute.")
+                await ctx.reply("Very well, come back when you would like to contribute.")
 
                 self.remove_from_interacting(ctx.author.id)
                 return
             elif msg.content.lower() not in confirm_text:
-                await utility.smart_reply(ctx, "I'm not entirely sure what that is, please try again.")
+                await ctx.reply("I'm not entirely sure what that is, please try again.")
 
                 self.remove_from_interacting(ctx.author.id)
                 return
@@ -6369,7 +6321,7 @@ anarchy - 1000% of your wager.
                 current_fuel = user_account.get(values.fuel.text)
                 daily_fuel = user_account.get("daily_fuel")
                 
-                await utility.smart_reply(ctx, f"You are trying to travel through the wormhole.\nThis will require **{utility.smart_number(move_cost)}** {values.fuel.text}.\nYou have {utility.smart_number(current_fuel)} {values.fuel.text} and {utility.smart_number(daily_fuel)} {values.daily_fuel.text}.\nAre you sure you want to move? Yes or No.")
+                await ctx.reply(f"You are trying to travel through the wormhole.\nThis will require **{utility.smart_number(move_cost)}** {values.fuel.text}.\nYou have {utility.smart_number(current_fuel)} {values.fuel.text} and {utility.smart_number(daily_fuel)} {values.daily_fuel.text}.\nAre you sure you want to move? Yes or No.")
             
                 def check(m: discord.Message):
                     return m.author.id == ctx.author.id and m.channel.id == ctx.channel.id 
@@ -6377,17 +6329,17 @@ anarchy - 1000% of your wager.
                 try:
                     msg = await self.bot.wait_for('message', check = check, timeout = 60.0)
                 except asyncio.TimeoutError: 
-                    await utility.smart_reply(ctx, f"Autopilot error:\nConfirmation timeout, aborting.")
+                    await ctx.reply(f"Autopilot error:\nConfirmation timeout, aborting.")
                     self.remove_from_interacting(ctx.author.id)
                     return
                 
                 if msg.content.lower() in cancel_text:
-                    await utility.smart_reply(ctx, "Autopilot error:\nCancelled.")
+                    await ctx.reply("Autopilot error:\nCancelled.")
 
                     self.remove_from_interacting(ctx.author.id)
                     return
                 elif msg.content.lower() not in confirm_text:
-                    await utility.smart_reply(ctx, "Autopilot error:\nUnrecognized confirmation response, aborting.")
+                    await ctx.reply("Autopilot error:\nUnrecognized confirmation response, aborting.")
 
                     self.remove_from_interacting(ctx.author.id)
                     return
@@ -6397,7 +6349,7 @@ anarchy - 1000% of your wager.
             player_fuel = fuel_item + daily_fuel
 
             if player_fuel < move_cost:
-                await utility.smart_reply(ctx, "Autopilot error:\nLacking required fuel, aborting.")
+                await ctx.reply("Autopilot error:\nLacking required fuel, aborting.")
 
                 self.remove_from_interacting(ctx.author.id)
                 return
@@ -6444,7 +6396,7 @@ anarchy - 1000% of your wager.
                 reduced_info = True
                 )
             else:
-                await utility.smart_reply(ctx, message_content)
+                await ctx.reply(message_content)
 
             self.remove_from_interacting(ctx.author.id)
             return
@@ -6576,7 +6528,7 @@ anarchy - 1000% of your wager.
             current_fuel = user_account.get(values.fuel.text)
             daily_fuel = user_account.get("daily_fuel")
 
-            await utility.smart_reply(ctx, f"You are trying to move from {start_location} to {end_location}.\nThis will require **{utility.smart_number(move_cost)}** {values.fuel.text}.\nYou have {utility.smart_number(current_fuel)} {values.fuel.text} and {utility.smart_number(daily_fuel)} {values.daily_fuel.text}.\nAre you sure you want to move? Yes or No.")
+            await ctx.reply(f"You are trying to move from {start_location} to {end_location}.\nThis will require **{utility.smart_number(move_cost)}** {values.fuel.text}.\nYou have {utility.smart_number(current_fuel)} {values.fuel.text} and {utility.smart_number(daily_fuel)} {values.daily_fuel.text}.\nAre you sure you want to move? Yes or No.")
             
             def check(m: discord.Message):
                 return m.author.id == ctx.author.id and m.channel.id == ctx.channel.id 
@@ -6585,17 +6537,17 @@ anarchy - 1000% of your wager.
             try:
                 msg = await self.bot.wait_for('message', check = check, timeout = 60.0)
             except asyncio.TimeoutError: 
-                await utility.smart_reply(ctx, f"Autopilot error:\nConfirmation timeout, aborting.")
+                await ctx.reply(f"Autopilot error:\nConfirmation timeout, aborting.")
                 self.remove_from_interacting(ctx.author.id)
                 return
             
             if msg.content.lower() in cancel_text:
-                await utility.smart_reply(ctx, "Autopilot error:\nCancelled.")
+                await ctx.reply("Autopilot error:\nCancelled.")
 
                 self.remove_from_interacting(ctx.author.id)
                 return
             elif msg.content.lower() not in confirm_text:
-                await utility.smart_reply(ctx, "Autopilot error:\nUnrecognized confirmation response, aborting.")
+                await ctx.reply("Autopilot error:\nUnrecognized confirmation response, aborting.")
 
                 self.remove_from_interacting(ctx.author.id)
                 return
@@ -6605,7 +6557,7 @@ anarchy - 1000% of your wager.
         player_fuel = fuel_item + daily_fuel
 
         if player_fuel < move_cost:
-            await utility.smart_reply(ctx, "Autopilot error:\nLacking required fuel, aborting.")
+            await ctx.reply("Autopilot error:\nLacking required fuel, aborting.")
 
             self.remove_from_interacting(ctx.author.id)
             return
@@ -6696,7 +6648,7 @@ anarchy - 1000% of your wager.
                 reduced_info = True
             )
         else:
-            await utility.smart_reply(ctx, message_content)
+            await ctx.reply(message_content)
 
         self.remove_from_interacting(ctx.author.id)
 
@@ -6720,7 +6672,7 @@ anarchy - 1000% of your wager.
             amount: typing.Optional[parse_int] = commands.parameter(description = "The amount of Anarchy Chessatrons to create.")
         ):
         if get_channel_permission_level(ctx) < PERMISSION_LEVEL_ACTIVITIES:
-            await utility.smart_reply(ctx, f"Thank you for your interest in creating anarchy chessatrons! You can do so over in {self.json_interface.get_rolling_channel(ctx.guild.id)}.")
+            await ctx.reply(f"Thank you for your interest in creating anarchy chessatrons! You can do so over in {self.json_interface.get_rolling_channel(ctx.guild.id)}.")
             return
         
         if amount is not None:
@@ -6792,31 +6744,31 @@ anarchy - 1000% of your wager.
         # then we send the tron messages
         if trons_to_make < 3:
             for _ in range(trons_to_make):
-                await utility.smart_reply(ctx, f"You've collected all the anarchy pieces! Congratulations!")
+                await ctx.reply(f"You've collected all the anarchy pieces! Congratulations!")
                 await asyncio.sleep(1)
 
-                await utility.smart_reply(ctx, board)
+                await ctx.reply(board)
                 await asyncio.sleep(1)
 
-                await utility.smart_reply(ctx, f"For an incredible feat like this, you have been awarded the Anarchy Chessatron!")
+                await ctx.reply(f"For an incredible feat like this, you have been awarded the Anarchy Chessatron!")
                 await asyncio.sleep(1)
 
-                await utility.smart_reply(ctx, values.anarchy_chessatron.text)
+                await ctx.reply(values.anarchy_chessatron.text)
                 await asyncio.sleep(1)
 
-                await utility.smart_reply(ctx, f"Amazing work! You have also been awarded **{utility.smart_number(total_dough_value//trons_to_make)} dough!**")
+                await ctx.reply(f"Amazing work! You have also been awarded **{utility.smart_number(total_dough_value//trons_to_make)} dough!**")
                 await asyncio.sleep(1)
 
         elif trons_to_make < 20:
             for _ in range(trons_to_make):
-                await utility.smart_reply(ctx, f"Very well done! You have collected all the anarchy pieces!\n\n{board}")
+                await ctx.reply(f"Very well done! You have collected all the anarchy pieces!\n\n{board}")
                 await asyncio.sleep(1)
 
-                await utility.smart_reply(ctx, f"Not only have you been awarded the prestigious {values.anarchy_chessatron.text}, but you also have been awarded **{utility.smart_number(total_dough_value//trons_to_make)} dough**!")
+                await ctx.reply(f"Not only have you been awarded the prestigious {values.anarchy_chessatron.text}, but you also have been awarded **{utility.smart_number(total_dough_value//trons_to_make)} dough**!")
                 await asyncio.sleep(1)
 
         elif trons_to_make < 5000:
-            await utility.smart_reply(ctx, f"You've collected all the anarchy pieces again! Great job! You have enough pieces to make {utility.smart_number(trons_to_make)} Anarchy Chessatrons! Here's your reward of **{utility.smart_number(total_dough_value)} dough**!")
+            await ctx.reply(f"You've collected all the anarchy pieces again! Great job! You have enough pieces to make {utility.smart_number(trons_to_make)} Anarchy Chessatrons! Here's your reward of **{utility.smart_number(total_dough_value)} dough**!")
             await asyncio.sleep(1)
 
             max_per = 1800 // len(values.anarchy_chessatron.text)
@@ -6827,19 +6779,19 @@ anarchy - 1000% of your wager.
             if full_messages >= 1:
                 send = values.anarchy_chessatron.text * max_per
                 for _ in range(full_messages):
-                    await utility.smart_reply(ctx, send)
+                    await ctx.reply(send)
                     await asyncio.sleep(1)
             
             if extra >= 1:
-                await utility.smart_reply(ctx, values.anarchy_chessatron.text * extra)
+                await ctx.reply(values.anarchy_chessatron.text * extra)
                 await asyncio.sleep(1)
 
 
         else:
-            await utility.smart_reply(ctx, f"Wow! You have so many anarchy pieces! In fact, you have enough to make a shocking {utility.smart_number(trons_to_make)} Anarchy Chessatrons!")
+            await ctx.reply(f"Wow! You have so many anarchy pieces! In fact, you have enough to make a shocking {utility.smart_number(trons_to_make)} Anarchy Chessatrons!")
             await asyncio.sleep(1)
 
-            await utility.smart_reply(ctx, f"Here are your new Anarchy Chessatrons:\n{values.anarchy_chessatron.text} x {utility.smart_number(trons_to_make)}\n\nAnd here is your **{utility.smart_number(total_dough_value)} dough**!")
+            await ctx.reply(f"Here are your new Anarchy Chessatrons:\n{values.anarchy_chessatron.text} x {utility.smart_number(trons_to_make)}\n\nAnd here is your **{utility.smart_number(total_dough_value)} dough**!")
             await asyncio.sleep(1)
 
     #############################################################################################################################

--- a/bread_cog.py
+++ b/bread_cog.py
@@ -6170,12 +6170,15 @@ anarchy - 1000% of your wager.
         message_lines += "\n\n**# -- Projects --**"
 
         for project_id, data in enumerate(hub_projects[:hub.project_count]):
+            contributions = data.get('contributions')
+
             message_lines += f"#{project_id + 1}: "
             message_lines += data.get("project").display_info(
                 day_seed = day_seed,
                 system_tile = hub,
                 compress_description = True,
-                completed = data.get("completed", False)
+                completed = data.get("completed", False),
+                item_information = contributions
             )
             message_lines += "\n\n"
         

--- a/bread_cog.py
+++ b/bread_cog.py
@@ -6,6 +6,9 @@ Patch 27.11:
 - Projects and planet rolling odds now refresh twice per day. Once at bread o' clock and once 12 hours later.
 - Some internal changes have been made with how the map works, nothing should be different except the galaxy map should be generated slightly faster now with higher telescope levels.
 - It will now say how long it took the map to generate. This was originally just for development but Lilly wanted it to be kept.
+- You can now use `$bread hub contribute <project> all <item>` to contribute as much as you can to a project.
+- Fixed bug where running `$bread hub contribute` without any parameters would break.
+- Slightly changed planet rolling odds math.
 
 
 (todo) test reply ping

--- a/bread_cog.py
+++ b/bread_cog.py
@@ -5568,6 +5568,10 @@ anarchy - 1000% of your wager.
 
         actions += [" ", " ", " ", " "]
 
+        if actions[1] == " ":
+            await ctx.reply("To contribute to a project, use this format:\n'$bread space hub contribute [project number] [amount] [item]'")
+            return
+        
         try:
             if actions[1] == "level":
                 project_number = "level"

--- a/bread_cog.py
+++ b/bread_cog.py
@@ -6790,7 +6790,7 @@ anarchy - 1000% of your wager.
                 await utility.smart_reply(ctx, board)
                 await asyncio.sleep(1)
 
-                await utility.smart_reply(ctx, f"For an incredible feat like this, you have been awared the Anarchy Chessatron!")
+                await utility.smart_reply(ctx, f"For an incredible feat like this, you have been awarded the Anarchy Chessatron!")
                 await asyncio.sleep(1)
 
                 await utility.smart_reply(ctx, values.anarchy_chessatron.text)

--- a/bread_cog.py
+++ b/bread_cog.py
@@ -5008,6 +5008,10 @@ anarchy - 1000% of your wager.
         if account.has("engine_efficiency"):
             level = account.get('engine_efficiency')
             output.append(f"You use {round((1 - store.Engine_Efficiency.consumption_multipliers[level]) * 100)}% less fuel with {account.write_count('engine_efficiency', 'level')} of Engine Efficiency.")
+
+        if account.has("payment_bonus"):
+            level = account.get('payment_bonus')
+            output.append(f"You've recieved {utility.write_count(level, 'dubious bonus', 'e')} so far, and that gets you {level * 100} more {values.project_credits.text} per day.")
         
         output.append("")
         output.append(f"Throughout your time in space you've created {utility.write_count(account.get('trade_hubs_created'), 'Trade Hub')} and helped contribute to {utility.write_count(account.get('projects_completed'), 'completed project')}.")

--- a/bread_cog.py
+++ b/bread_cog.py
@@ -2796,6 +2796,9 @@ loaf_converter""",
             purchasable_set = set(items)
             item_set = set(store.prestige_store_items)
             non_purchasable_items = item_set - purchasable_set # type: set[store.Prestige_Store_Item]
+
+            displayed_items = 0
+
             for item in list(non_purchasable_items):
                 if user_account.get(item.name) >= item.max_level(user_account):
                     continue
@@ -2806,8 +2809,9 @@ loaf_converter""",
                     continue
 
                 output += f"*{item.display_name}: {requirement}*\n\n"
+                displayed_items += 1
             
-            if len(items) == 0:
+            if displayed_items == 0:
                 output += "**It looks like you've bought everything here. Well done.**"
             else:
                 output += 'To buy an item, just type "$bread buy [item name]".'
@@ -5091,6 +5095,9 @@ anarchy - 1000% of your wager.
 
         output = ""
         output += f"Welcome to the Space Shop!\nHere are the items available for purchase:\n\n"
+
+        displayed_items = 0
+
         for item in item_list:
             requirement_given = False
             requirement = None
@@ -5114,8 +5121,10 @@ anarchy - 1000% of your wager.
                     output += f"*Not purchasable right now. {requirement}*\n"
                     
                 output += "\n"
+
+                displayed_items += 1
         
-        if len(items) == 0:
+        if displayed_items == 0:
             output += "**It looks like you've bought everything here. Well done.**"
         else:
             output += 'To buy an item, just type "$bread buy [item name]".'
@@ -6782,7 +6791,6 @@ anarchy - 1000% of your wager.
 
         # then we send the tron messages
         if trons_to_make < 3:
-            print(board)
             for _ in range(trons_to_make):
                 await utility.smart_reply(ctx, f"You've collected all the anarchy pieces! Congratulations!")
                 await asyncio.sleep(1)
@@ -7526,6 +7534,7 @@ anarchy - 1000% of your wager.
 
         items.append(values.ascension_token)
         items.append(values.normal_bread)
+        items.append(values.corrupted_bread)
         items.append(values.anarchy_chess)
         items.append(values.chessatron)
         items.append(values.anarchy_chessatron)

--- a/bread_cog.py
+++ b/bread_cog.py
@@ -5355,6 +5355,7 @@ anarchy - 1000% of your wager.
             analysis_lines = tile_analyze.get_analysis(
                 guild = ctx.guild.id,
                 json_interface = self.json_interface,
+                user_account = user_account,
                 detailed = detailed
             )
         else:

--- a/bread_cog.py
+++ b/bread_cog.py
@@ -5185,7 +5185,7 @@ anarchy - 1000% of your wager.
             color=8884479,
         )
         unfortunate_embed.set_image(url=file_path)
-        unfortunate_embed.set_footer(text=f"Map generated in {round(after-before, 3)} seconds.")
+        unfortunate_embed.set_footer(text=f"Map generated in {round(after - before, 3)} seconds.")
 
         return await ctx.reply(content, embed=unfortunate_embed, file=send_file)
 
@@ -5310,6 +5310,7 @@ anarchy - 1000% of your wager.
         
         ##########################################################
         ##### Generating the map.
+        before = time.time()
 
         map_path = space.space_map(
             account = user_account,
@@ -5318,6 +5319,7 @@ anarchy - 1000% of your wager.
             analyze_position = point.lower()
         )
 
+        after = time.time()
         ##########################################################
         ##### Getting the analysis data.
 
@@ -5380,6 +5382,7 @@ anarchy - 1000% of your wager.
             color=8884479,
         )
         embed_send.set_image(url=file_path)
+        embed_send.set_footer(text=f"Analysis generated in {round(after - before, 3)} seconds.")
         
         await ctx.reply(embed=embed_send, file=send_file)
 

--- a/bread_cog.py
+++ b/bread_cog.py
@@ -2,19 +2,8 @@
 HOW TO UNRESTRICT SPACE TO a9:
 - Go to Bread_cog.space_shop and remove the if that's "if user_account.get_prestige_level() < 9:"
 
-Patch Notes: 
-- Added space.
-  - Currently only available on a9, when a9 finishes it will be available from a2 and above.
-  - Added a Space Shop accessible via "$bread space shop"
-  - In order to access space you need to purchase a Bread Rocket in the Space Shop.
-  - The anarchy piece set can be found when bread rolling in space.
-- Special and rare bread can now be alchemized out of :bread: and other specials of the same rarity.
-- You can now use fractions in gifting to specify a custom amount.
-- Modified Chessatron dough equation to buff Chessatron Contraption.
-- Decreased Chessatron Contraption max level to 10.
-- Changed the Random Chess Piece price scheme to be the chessatron value divided by 6, rounded up to the nearest 50.
-- You can now buy up to 2,500 Random Chess Pieces and 5,000,000 Special Bread Packs per day.
-- You can now ascend to the highest ascension from any ascension if you have the ascension requirements on your current ascension.
+Patch 27.11:
+- Projects and planet rolling odds now refresh twice per day. Once at bread o' clock and once 12 hours later.
 
 
 (todo) test reply ping
@@ -864,6 +853,11 @@ class Bread_cog(commands.Cog, name="Bread"):
             self.reset_internal() # this resets all roll counts to 0
             print("Daily reset called")
             await self.announce("bread_o_clock", "It's Bread O'Clock!")
+        
+        #run at 3am
+        elif time.hour == 3:
+            print("Mid-day space reset called")
+            self.reset_space_all()
 
         # every 6 hours, based around 3pm
         # print (f"Hour +15 %6 is {(time.hour + 15) % 6}")
@@ -7259,11 +7253,11 @@ anarchy - 1000% of your wager.
         self.reset_internal()
         await ctx.send("Done.")
 
-    def reset_space(
+    def reset_space_guild(
             self: typing.Self,
             guild: typing.Union[discord.Guild,str,int]
         ) -> None:
-        """Daily reset for Bread Space."""
+        """Twice per day reset for Bread Space."""
 
         # Set a new day seed.
         space_data = self.json_interface.get_space_data(guild=guild)
@@ -7288,6 +7282,15 @@ anarchy - 1000% of your wager.
             space_data[ascension_key] = ascension_data
 
         self.json_interface.set_custom_file("space", file_data=space_data, guild=guild)
+    
+    def reset_space_all(self: typing.Self) -> None:
+        """Twice per day space reset for all guilds in the JSON interface."""
+        print("Bread Space: Running twice per day reset on all guilds.")
+
+        for guild_id in self.json_interface.get_list_of_all_guilds():
+            self.reset_space_guild(guild_id)
+        
+        print("Bread Space: Done.")
 
     def reset_internal(
             self: typing.Self,
@@ -7298,6 +7301,8 @@ anarchy - 1000% of your wager.
         print("Internal daily reset called")
         self.currently_interacting.clear()
 
+        self.reset_space_all()
+
         if guild is not None:
             guild_id = get_id_from_guild(guild)
 
@@ -7307,8 +7312,6 @@ anarchy - 1000% of your wager.
                 self.json_interface.set_account(account.get("id"), account, guild_id)
         else: #call for all accounts
             for guild_id in self.json_interface.get_list_of_all_guilds():
-                self.reset_space(guild_id)
-
                 for account in self.json_interface.get_all_user_accounts(guild_id):
                     account.daily_reset()
                     self.json_interface.set_account(account.get("id"), account, guild_id)
@@ -7523,6 +7526,8 @@ anarchy - 1000% of your wager.
 
         # self.currently_interacting.clear()
 
+        # await self.daily_task()
+
         ##########################################################
         # Go through all trade hubs and set them to be at [0, 1] #
         # for guild in self.json_interface.all_guilds:
@@ -7538,27 +7543,27 @@ anarchy - 1000% of your wager.
         #     self.json_interface.set_custom_file("space", space_data, guild)
 
         # When the rocket tiers were shifted and tier 3 was removed this'll correct everyone stats.
-        for guild in self.json_interface.all_guilds:
-            for account in self.json_interface.get_all_user_accounts(guild=guild):
-                space_level = account.get_space_level()
-                if space_level >= 3:
-                    account.increment("space_level", -1)
+        # for guild in self.json_interface.all_guilds:
+        #     for account in self.json_interface.get_all_user_accounts(guild=guild):
+        #         space_level = account.get_space_level()
+        #         if space_level >= 3:
+        #             account.increment("space_level", -1)
                 
-                fr_level = account.get("fuel_research")
+        #         fr_level = account.get("fuel_research")
 
-                if fr_level > 2:
-                    account.increment("fuel_research", -1)
-                    account.increment(values.gem_green, 100)
+        #         if fr_level > 2:
+        #             account.increment("fuel_research", -1)
+        #             account.increment(values.gem_green, 100)
 
-                if fr_level > 2:
-                    account.increment("fuel_research", -1)
-                    account.increment(values.gem_gold, 100)
+        #         if fr_level > 2:
+        #             account.increment("fuel_research", -1)
+        #             account.increment(values.gem_gold, 100)
 
-                if fr_level == 2 and space_level < 4:
-                    account.increment("fuel_research", -1)
-                    account.increment(values.gem_purple, 100)
+        #         if fr_level == 2 and space_level < 4:
+        #             account.increment("fuel_research", -1)
+        #             account.increment(values.gem_purple, 100)
 
-                self.json_interface.set_account(account.user_id, account, guild)
+        #         self.json_interface.set_account(account.user_id, account, guild)
 
 
 

--- a/chess_bot.py
+++ b/chess_bot.py
@@ -729,7 +729,7 @@ class Chess_bot(commands.Cog, name="Chess"):
             work_board.push_san(move_string)
             pass
         except ValueError:
-            await utility.smart_reply(ctx, "It seems that is not a legal move, or is not properly specified.\nApologies, but I am not currently capable of performing that.")
+            await ctx.reply("It seems that is not a legal move, or is not properly specified.\nApologies, but I am not currently capable of performing that.")
         else:
             current_game.add_move(ctx.message.author, move_string) #adds the move to the list
             #await self.print_board(ctx, work_board)
@@ -747,7 +747,7 @@ class Chess_bot(commands.Cog, name="Chess"):
                 await current_game.end_game()
         pass
         if brick:
-            await utility.smart_reply(ctx, "You declined en passant. Tsk, tsk.")
+            await ctx.reply("You declined en passant. Tsk, tsk.")
             #JSON_cog = bot_ref.get_cog("JSON")
             #bot_ref.brick(ctx, ctx.author)
             await ctx.invoke(self.bot.get_command('brick'), member=ctx.author, duration=None)
@@ -786,17 +786,17 @@ class Chess_bot(commands.Cog, name="Chess"):
                     await ctx.send("You must wait until your turn to offer a draw.")
                     return
                 else:
-                    await utility.smart_reply(ctx, "You aren't authorized to offer a draw from White.")
+                    await ctx.reply("You aren't authorized to offer a draw from White.")
                     return
             # if white has already started the offer and it is black's job to respond
             elif (current_game.white_offers_draw is True):
                 # if black is responding with acceptance
                 if (ctx.author in current_game.players_black):
-                    await utility.smart_reply(ctx, "The game has been drawn.")
+                    await ctx.reply("The game has been drawn.")
                     await current_game.end_game(reason = "both players agreed to a draw.")
                     return
                 else:
-                    await utility.smart_reply(ctx, "You aren't authorized to offer a draw from Black.")
+                    await ctx.reply("You aren't authorized to offer a draw from Black.")
                     return
 
         else: # turn is BLACK
@@ -811,17 +811,17 @@ class Chess_bot(commands.Cog, name="Chess"):
                     await ctx.send("You must wait until your turn to offer a draw.")
                     return
                 else:
-                    await utility.smart_reply(ctx, "You aren't authorized to offer a draw from Black.")
+                    await ctx.reply("You aren't authorized to offer a draw from Black.")
                     return
             # if black has already started the offer and it is white's job to respond
             elif (current_game.black_offers_draw is True):
                 # if white is responding with acceptance
                 if (ctx.author in current_game.players_white):
-                    await utility.smart_reply(ctx, "The game has been drawn.")
+                    await ctx.reply("The game has been drawn.")
                     await current_game.end_game(reason = "both players agreed to a draw.")
                     return
                 else:
-                    await utility.smart_reply(ctx, "You aren't authorized to offer a draw from White.")
+                    await ctx.reply("You aren't authorized to offer a draw from White.")
                     return
 
     ##############################################################################################################################################################
@@ -847,7 +847,7 @@ class Chess_bot(commands.Cog, name="Chess"):
         #white_requests_takeback = False
 
         if len(current_game.moves) == 0:
-            await utility.smart_reply(ctx, "There are not enough moves to take back.")
+            await ctx.reply("There are not enough moves to take back.")
             return
         
         # is black who messed up and is requesting the takeback
@@ -864,13 +864,13 @@ class Chess_bot(commands.Cog, name="Chess"):
                     await ctx.send("You cannot request a takeback on your own turn.")
                     return
                 else:
-                    await utility.smart_reply(ctx, "You aren't authorized to request a takeback.")
+                    await ctx.reply("You aren't authorized to request a takeback.")
                     return
             # if black has already started the offer and it is black's job to respond
             elif (current_game.black_requests_takeback is True):
                 # if white is responding with acceptance
                 if (ctx.author in current_game.players_white):
-                    #await utility.smart_reply(ctx, "The game has been drawn.")
+                    #await ctx.reply("The game has been drawn.")
                     #await current_game.end_game(reason = "both players agreed to a draw.")
                     work_board.pop() #pops the move from the board itself
                     current_game.moves.pop() #pops the move from the internal move list
@@ -878,7 +878,7 @@ class Chess_bot(commands.Cog, name="Chess"):
                     await self.print_game(current_game)
                     return
                 else:
-                    await utility.smart_reply(ctx, "You aren't authorized to accept that takeback.")
+                    await ctx.reply("You aren't authorized to accept that takeback.")
                     return
 
         else: # turn is BLACK
@@ -893,13 +893,13 @@ class Chess_bot(commands.Cog, name="Chess"):
                     await ctx.send("You cannot request a takeback on your own turn.")
                     return
                 else:
-                    await utility.smart_reply(ctx, "You aren't authorized to request a takeback.")
+                    await ctx.reply("You aren't authorized to request a takeback.")
                     return
             # if white has already started the request and it is black's job to respond
             elif (current_game.white_requests_takeback is True):
                 # if black is responding with acceptance
                 if (ctx.author in current_game.players_black):
-                    #await utility.smart_reply(ctx, "The game has been drawn.")
+                    #await ctx.reply("The game has been drawn.")
                     #await current_game.end_game(reason = "both players agreed to a draw.")
                     work_board.pop() #pops the move from the board itself
                     current_game.moves.pop() #pops the move from the internal move list
@@ -907,7 +907,7 @@ class Chess_bot(commands.Cog, name="Chess"):
                     await self.print_game(current_game)
                     return
                 else:
-                    await utility.smart_reply(ctx, "You aren't authorized to accept that takeback.")
+                    await ctx.reply("You aren't authorized to accept that takeback.")
                     return
 
     ##############################################################################################################################################################
@@ -925,20 +925,20 @@ class Chess_bot(commands.Cog, name="Chess"):
 
         if (turn == chess.WHITE and ctx.author in current_game.players_white):
             await current_game.end_game(reason = "White resigned.")
-            await utility.smart_reply(ctx, "White resigned.")
+            await ctx.reply("White resigned.")
         elif (turn == chess.BLACK and ctx.author in current_game.players_black):
             await current_game.end_game(reason = "Black resigned.")
-            await utility.smart_reply(ctx, "Black resigned.")
+            await ctx.reply("Black resigned.")
 
         #second batch, for not the person's turn
         elif (ctx.author in current_game.players_white):
             await current_game.end_game(reason = "White resigned.")
-            await utility.smart_reply(ctx, "White resigned.")
+            await ctx.reply("White resigned.")
         elif (ctx.author in current_game.players_black):
             await current_game.end_game(reason = "Black resigned.")
-            await utility.smart_reply(ctx, "Black resigned.")
+            await ctx.reply("Black resigned.")
         else:
-            await utility.smart_reply(ctx, "Only a player in the game may resign.")
+            await ctx.reply("Only a player in the game may resign.")
 
     ###############################
     ########    GAME    ###########
@@ -959,7 +959,7 @@ class Chess_bot(commands.Cog, name="Chess"):
         #three-check
         #board = chess.variant.find_variant("name: str") 
         pass
-        await utility.smart_reply(ctx, "This command doesn't do anything yet.")
+        await ctx.reply("This command doesn't do anything yet.")
 
     # takes 960, or a name, or both
     @chess.command( hidden = True)

--- a/chess_bot.py
+++ b/chess_bot.py
@@ -750,7 +750,7 @@ class Chess_bot(commands.Cog, name="Chess"):
             await ctx.reply("You declined en passant. Tsk, tsk.")
             #JSON_cog = bot_ref.get_cog("JSON")
             #bot_ref.brick(ctx, ctx.author)
-            await ctx.invoke(self.bot.get_command('brick'), member=ctx.author, duration=None)
+            await ctx.invoke(self.bot.get_command('brick'), member=ctx.author)
         
 
     ##############################################################################################################################################################

--- a/main.py
+++ b/main.py
@@ -12,6 +12,7 @@ from os import getenv
 #from verification import from_owner
 #from verification import get_rejection_reason
 import verification
+import bread.utility as utility
 """
 #local imports
 import roles
@@ -34,7 +35,8 @@ intents.messages = True
 intents.guilds = True
 intents.message_content = True
 
-bot = commands.Bot(command_prefix=COMMAND_PREFIX, intents=intents, owner_id=OWNER_ID)
+bot = utility.CustomBot(command_prefix=COMMAND_PREFIX, intents=intents, owner_id=OWNER_ID)
+# bot = commands.Bot(command_prefix=COMMAND_PREFIX, intents=intents, owner_id=OWNER_ID)
 
 
 #intents = discord.Intents(messages=True, guilds=True, members=True)


### PR DESCRIPTION
Patch 27.11:
- Projects and planet rolling odds now refresh twice per day. Once at bread o' clock and once 12 hours later. This does not refresh project credits, however.
- Some internal changes for the following things:
  - Some things with the map have been changed, nothing should be different except the galaxy map should be generated slightly faster now with higher telescope levels. This change should mean it's easier to modify the map in the future.
  - A new smart reply method has been introduced, so hopefully everything will use smart replies automatically.
- The map will now say how long it took to generate.
- You can now use `$bread hub contribute <project> all <item>` to contribute as much as you can to a project.
- Slightly changed planet rolling odds math.
- Anarchy pieces can now get corrupted and turn into corrupted bread in certain situations when rolling.
- Fixed bug where running `$bread hub contribute` without any parameters would break.
- Fixed typo in anarchy chessatron animation.
- Fixed declining en passant not bricking you.
- Some more information has been added to analyses.
- The main Trade Hub section will now display the requirement and reward for each project if the project has not been completed.
- You can once again play the Bread Game in a thread:
  - This time it's actually intentional.
  - Only threads off of <#967544442468843560> and <#1063317762191147008> are allowed.
  - All threads have the same permission level as <#1063317762191147008>, so you can gamble, do alchemy, and other stuff, but cannot bread roll.
  - Only public threads can be used, so private threads won't work.
- Added a new Space Shop item, the Payment Bonus. It's unlocked at the rocket tier 3 and increases the amount of <:project_credits:1299459973142679653> you get per day.