### PR TITLE
Patch 27.12

### DIFF
--- a/bread/account.py
+++ b/bread/account.py
@@ -441,8 +441,8 @@ class Bread_Account:
         ) -> float:
         """Returns the luck of anarchy pieces. `roll_luck` is assumed to be `(loaf_converter + 1) * recipe_refinement_multiplier`"""
         return min(
-            round(1 + (store.Advanced_Exploration.per_level * self.get(store.Advanced_Exploration.name)) * (roll_luck - self.get_recipe_refinement_multiplier()), 5),
-            128 # 128 is the cap.
+            round(1 + store.Advanced_Exploration.get_contribution(self) * (roll_luck - self.get_recipe_refinement_multiplier()), 5),
+            64 # 64 is the cap.
         )
     
     def get_projects_credits_cap(self: typing.Self) -> int:

--- a/bread/account.py
+++ b/bread/account.py
@@ -129,6 +129,7 @@ class Bread_Account:
         emotes_to_remove.append(values.normal_bread)
         emotes_to_remove.append(values.anarchy_chess)
         emotes_to_remove.append(values.fuel)
+        emotes_to_remove.append(values.corrupted_bread)
         # we're keeping OoaKs
 
         entries_to_remove = [   "total_dough",
@@ -160,6 +161,9 @@ class Bread_Account:
         # convert moaks to shadows
         if self.get(values.anarchy_chess.text) > 0:
             self.increment(values.shadow_moak.text, self.get(values.anarchy_chess.text))
+        # convert anarchy omegas to shadows
+        if self.get(values.anarchy_omega_chessatron.text) > 0:
+            self.increment(values.anarchy_shadowmega.text, self.get(values.anarchy_omega_chessatron.text))
 
         for stat in lifetime_stats:
             if stat in self.values.keys():

--- a/bread/account.py
+++ b/bread/account.py
@@ -469,7 +469,7 @@ class Bread_Account:
 
     def get_shadowmega_boost_amount(self: typing.Self) -> int:
         """Returns the multiplier applied to omegas this player gets per chessatron from Chessatron Contraption and shadowmega chessatrons."""
-        return 1.05 ** self.get_shadowmega_boost_count()
+        return 1 + 0.02 * self.get_shadowmega_boost_count()
 
     def get_shadow_gold_gem_boost_count(self: typing.Self) -> int:
         """Returns the amount of shadow gold gems that this player can use to increase their odds of finding gems. Essentially, this is the number of active shadow gold gems."""

--- a/bread/projects.py
+++ b/bread/projects.py
@@ -316,23 +316,23 @@ class Trade_Hub(Project):
             ],
             # Level 2:
             [
-                (values.anarchy_chess.text, 5), (values.chessatron.text, 200),
-                (values.gem_gold.text, 37), (values.gem_green.text, 75), (values.gem_purple.text, 150), (values.gem_blue.text, 300), (values.gem_red.text, 900)
+                (values.anarchy_chess.text, 5), (values.chessatron.text, 10),
+                (values.gem_gold.text, 50), (values.gem_green.text, 100), (values.gem_purple.text, 200), (values.gem_blue.text, 400), (values.gem_red.text, 1200)
             ],
             # Level 3:
             [
-                (values.anarchy_chess.text, 10), (values.chessatron.text, 400),
-                (values.gem_gold.text, 56), (values.gem_green.text, 112), (values.gem_purple.text, 225), (values.gem_blue.text, 450), (values.gem_red.text, 1350)
+                (values.anarchy_chess.text, 5), (values.chessatron.text, 10),
+                (values.gem_gold.text, 50), (values.gem_green.text, 100), (values.gem_purple.text, 200), (values.gem_blue.text, 400), (values.gem_red.text, 1200)
             ],
             # Level 4:
             [
-                (values.anarchy_chess.text, 20), (values.chessatron.text, 800), (values.anarchy_chessatron.text, 1),
-                (values.gem_gold.text, 84), (values.gem_green.text, 168), (values.gem_purple.text, 337), (values.gem_blue.text, 675), (values.gem_red.text, 2025)
+                (values.anarchy_chess.text, 5), (values.chessatron.text, 10), (values.anarchy_chessatron.text, 1),
+                (values.gem_gold.text, 50), (values.gem_green.text, 100), (values.gem_purple.text, 200), (values.gem_blue.text, 400), (values.gem_red.text, 1200)
             ],
             # Level 5:
             [
-                (values.anarchy_chess.text, 40), (values.chessatron.text, 1600), (values.anarchy_chessatron.text, 2),
-                (values.gem_gold.text, 126), (values.gem_green.text, 253), (values.gem_purple.text, 506), (values.gem_blue.text, 1012), (values.gem_red.text, 3037)
+                (values.anarchy_chess.text, 5), (values.chessatron.text, 10), (values.anarchy_chessatron.text, 2),
+                (values.gem_gold.text, 50), (values.gem_green.text, 100), (values.gem_purple.text, 200), (values.gem_blue.text, 400), (values.gem_red.text, 1200)
             ],
         ]
     

--- a/bread/projects.py
+++ b/bread/projects.py
@@ -394,6 +394,8 @@ class Trade_Hub(Project):
 #######################################################################################################
 ##### Base project. ###################################################################################
 #######################################################################################################
+# While technically a functional project, this is just a base to copy from to make other projects.
+# It is not something that should be subclassed, the `Project` class is fine.
 
 class Base_Project(Project):
     """Written by ???."""
@@ -4430,7 +4432,7 @@ story_projects = [Essential_Oils, Bingobango]
 take_special_bread_projects = [Too_Much_Stuffing, Flatbread_Shortage, Appease_The_French, Croissant_Cravings, Beach_Disappearance]
 take_rare_bread_projects = [Ecosystem_Problem, Stolen_Donuts, Waffle_Machine]
 take_black_chess_piece_projects = [Board_Game_Festival, Electrical_Issue, Chess_Tournament, Diorama_Issue, Offering_Ritual_Duplicate, Royal_Summit_Duplicate]
-take_white_chess_piece_projects = [Board_Game_Festival_Duplicate, Royal_Summit, Offering_Ritual, Fortress_Building, Round_Table]
+take_white_chess_piece_projects = [Board_Game_Festival_Duplicate, Royal_Summit, Stolen_Bishops, Offering_Ritual, Fortress_Building, Round_Table]
 take_gem_projects = [Gem_Salesman, Generator_Breakdown, Jewelry_Store, Gem_Mining, Emergency_Fuel]
 take_misc_item_projects = [Chessatron_Repair, Omega_Order]
 

--- a/bread/space.py
+++ b/bread/space.py
@@ -753,6 +753,8 @@ class GalaxyTile:
             )
 
             self.raw_system_data = raw_data
+        else:
+            raw_data = self.raw_system_data
 
         # If the generated data is None, then return.
         # It should only be None if there isn't a system here, which should be prevented earlier, but just in case.

--- a/bread/space.py
+++ b/bread/space.py
@@ -1028,16 +1028,32 @@ def get_corruption_chance(
         xpos: int,
         ypos: int,
     ) -> float:
-    """Returns the chance of a loaf becoming corrupted for any point in the galaxy. Between 0 and 1."""
+    """Returns the chance of a loaf becoming corrupted for any point in the galaxy. Between 0 and 1.
+    
+    Subtract the map radius from a regular coordinate for this."""
     dist = math.hypot(xpos, ypos)
 
-    # The band where the chance is 0 is between ~80 and ~87.774.
-    if 80 <= dist <= 87.774:
+    # The band where the chance is 0 is between 80 and 87.
+    if 80 <= dist <= 87:
         return 0.0
+    
+    # f\left(x\right)=\left\{x\le2:99,2\le x\le80:\left(\frac{\cos\left(\left(x-2\right)\frac{\pi}{78}\right)}{2}+0.5\right)99,80<x<87:0,87\le x\le241.81799:\left(\frac{\cos\left(\frac{\left(x-87\right)\pi}{154.8179858682464038403596020291203352621852869144970764695290884}\right)}{-2}+0.5\right)99,x>241.81799:99\right\}
+    # Where `x` is the distance to (0, 0)
+    # lmao
 
-    # `\frac{d^{2.15703654359}}{1000}+118e^{-0.232232152965\left(\frac{d}{22.5}\right)^{2}}-19`
-    # where `d` is the distance to (0, 0).
-    return ((dist ** 2.15703654359 / 1000) + 118 * math.e ** (-0.232232152965 * (dist / 22.5) ** 2) - 19) / 100
+    # It's a piecewise function, so `if` statements are used.
+    if dist <= 2:
+        chance = 99
+    elif dist <= 80:
+        chance = (math.cos((dist - 2) * (math.pi / 78)) / 2 + 0.5) * 99
+    elif dist <= 87:
+        chance = 0
+    elif dist <= 241.81799:
+        chance = (math.cos(((dist - 87) * math.pi) / 154.8179858682464038403596020291203352621852869144970764695290884) / -2 + 0.5) * 99
+    else:
+        chance = 99
+
+    return chance / 100
 
 def get_anarchy_corruption_chance(
         xpos: int,

--- a/bread/store.py
+++ b/bread/store.py
@@ -1916,6 +1916,15 @@ class Advanced_Exploration(Space_Shop_Item):
     per_level = 0.00015
 
     @classmethod
+    def get_contribution(cls, level: int | account.Bread_Account) -> float:
+        if isinstance(level, account.Bread_Account):
+            level_use = level.get(cls.name)
+        else:
+            level_use = level
+
+        return math.log(level_use + 1, 11) / 2000
+
+    @classmethod
     def cost(cls, user_account: account.Bread_Account) -> list[tuple[values.Emote, int]]:
         level = user_account.get(cls.name)
 
@@ -1945,7 +1954,7 @@ class Advanced_Exploration(Space_Shop_Item):
     @classmethod
     def description(cls, user_account: account.Bread_Account) -> str:
         level = user_account.get(cls.name) + 1
-        return f"Advanced exploration devices allowing the use of {round(level * cls.per_level * 100, 4)}% of your Loaf Converters when rolling anarchy chess pieces, up to 127 Loaf Converters."
+        return f"Advanced exploration devices allowing the use of {round(cls.get_contribution(level) * 100, 4)}% of your Loaf Converters when rolling anarchy chess pieces, up to 63 Loaf Converters."
 
     @classmethod
     def get_cost_types(cls, user_account: account.Bread_Account, level: int = None):

--- a/bread/utility.py
+++ b/bread/utility.py
@@ -307,6 +307,14 @@ class CustomContext(commands.Context):
             return None
         
         try:
+            ping_data = self.bot.json_cog.get_filing_cabinet("ping_settings", guild=self.guild, create_if_nonexistent=True)
+            
+            if str(self.author.id) in ping_data:
+                kwargs["mention_author"] = ping_data.get(str(self.author.id), True)
+        except: # oh well
+            pass
+        
+        try:
             return await self.safe_reply(content, **copy.deepcopy(kwargs))
         except discord.HTTPException:
             # If something went wrong replying.

--- a/bread/values.py
+++ b/bread/values.py
@@ -898,11 +898,11 @@ shadowmega_chessatron = Emote(
 )
 
 anarchy_shadowmega = Emote(
-    text="<:thinkiesglasses:1099473087654789171>",
+    text="<:anarchy_shadowmega:1312486058541187246>",
     name="anarchy_shadowmega",
     attributes=["shadow"],
     giftable = False,
-    alternate_names = ["shadow_anarchy_omega", "shadow_anarchy_omega_tron", "shadowmega_anarchy_chessatron", "ashadowmega"]
+    alternate_names = ["shadow_anarchy_omega", "shadow_anarchy_omega_tron", "shadowmega_anarchy_chessatron", "ashadowmega", "anarchy_shadowmega_chessatron"]
 )
 
 shadow_emotes = [shadow_gem_gold, shadow_moak, shadowmega_chessatron, anarchy_shadowmega]

--- a/bread/values.py
+++ b/bread/values.py
@@ -897,7 +897,15 @@ shadowmega_chessatron = Emote(
     giftable = False
 )
 
-shadow_emotes = [shadow_gem_gold, shadow_moak, shadowmega_chessatron]
+anarchy_shadowmega = Emote(
+    text="<:thinkiesglasses:1099473087654789171>",
+    name="anarchy_shadowmega",
+    attributes=["shadow"],
+    giftable = False,
+    alternate_names = ["shadow_anarchy_omega", "shadow_anarchy_omega_tron", "shadowmega_anarchy_chessatron", "ashadowmega"]
+)
+
+shadow_emotes = [shadow_gem_gold, shadow_moak, shadowmega_chessatron, anarchy_shadowmega]
 
 ##################### MISC
 

--- a/bread_cog.py
+++ b/bread_cog.py
@@ -1118,8 +1118,17 @@ class Bread_cog(commands.Cog, name="Bread"):
     @bread.command(
         hidden=True,
     )
-    async def help(self, ctx):
-        await ctx.send_help(Bread_cog.bread)
+    async def help(self, ctx, *, subcommand: typing.Optional[str] = commands.parameter(description = "A subcommand to get the help for.")):
+        if subcommand is None:
+            subcommand = ""
+
+        command = bot_ref.get_command(f"bread {subcommand}")
+
+        if command is None:
+            await ctx.reply("I can't find that command.")
+            return
+
+        await ctx.send_help(command)
 
     ########################################################################################################################
     #####      BREAD WIKI

--- a/bread_cog.py
+++ b/bread_cog.py
@@ -7509,7 +7509,7 @@ anarchy - 1000% of your wager.
         for emote in items:
             account.set(emote.text, 50000000000)
         
-        for shop_item in store.space_shop_items:
+        for shop_item in store.all_store_items:
             account.set(shop_item.name, shop_item.max_level(account))
 
         account.set("fuel_tank", 40000)

--- a/bread_cog.py
+++ b/bread_cog.py
@@ -5095,9 +5095,9 @@ anarchy - 1000% of your wager.
             return
         
         # Temporarily lock all of space to a9 or higher. When a9 ends this should be removed.
-        if user_account.get_prestige_level() < 9:
-            await ctx.reply("Currently the Space Shop is only available on the 9th ascension. When that ascension ends it will be available from the first ascension onwards.")
-            return
+        # if user_account.get_prestige_level() < 9:
+        #     await ctx.reply("Currently the Space Shop is only available on the 9th ascension. When that ascension ends it will be available from the first ascension onwards.")
+        #     return
 
         # now we get the list of items
         items = self.get_buyable_items(user_account, store.space_shop_items)

--- a/bread_cog.py
+++ b/bread_cog.py
@@ -2796,17 +2796,17 @@ loaf_converter""",
             # now we get the list of items
             items = self.get_buyable_items(user_account, store.prestige_store_items)
     
+            displayed_items = 0
             output = ""
             output += f"Welcome to the hidden bakery! All upgrades in this shop are permanent, and persist through ascensions. You have **{utility.smart_number(user_account.get(values.ascension_token.text))} {values.ascension_token.text}**.\n\*Prices subject to change.\nHere are the items available for purchase:\n\n"
             for item in items:
                 output += f"\t**{item.display_name}** - {item.get_price_description(user_account)}\n{item.description(user_account)}\n\n"
+                displayed_items += 1
 
             # Add lines for non-purchasable items that have a requirement if the item isn't at the max level.
             purchasable_set = set(items)
             item_set = set(store.prestige_store_items)
             non_purchasable_items = item_set - purchasable_set # type: set[store.Prestige_Store_Item]
-
-            displayed_items = 0
 
             for item in list(non_purchasable_items):
                 if user_account.get(item.name) >= item.max_level(user_account):
@@ -2818,7 +2818,6 @@ loaf_converter""",
                     continue
 
                 output += f"*{item.display_name}: {requirement}*\n\n"
-                displayed_items += 1
             
             if displayed_items == 0:
                 output += "**It looks like you've bought everything here. Well done.**"

--- a/bread_cog.py
+++ b/bread_cog.py
@@ -7575,6 +7575,37 @@ anarchy - 1000% of your wager.
         await ctx.send("Done.")
 
     ########################################################################################################################
+    #####      ADMIN BEQUEATH_CHERRY
+    
+    @admin.command(
+        brief="Remove the cherry.",
+        help = "Usage: bread admin bequeath_cherry"
+    )
+    @commands.check(verification.is_admin_check)
+    async def bequeath_cherry(self, ctx):
+        if not await self.await_confirmation(ctx):
+            return
+        
+        all_accounts = self.json_interface.get_all_user_accounts(ctx.guild)
+
+        removed = [] # type: list[account.Bread_Account]
+
+        for account in all_accounts:
+            if account.has(values.cherry.text):
+                account.set(values.cherry.text, 0)
+                removed.append(account)
+
+                self.json_interface.set_account(account.get("id"), account, ctx.guild)
+        
+        await ctx.reply("Done.\n{} affected:\n{}".format(
+            utility.write_count(len(removed), 'account'),
+            "\n".join([
+                f"- {account.get_display_name()} ({account.get('id')})"
+                for account in removed
+            ])
+        ))
+
+    ########################################################################################################################
     #####      ADMIN DO_OPERATION
     
     @admin.command(

--- a/bread_cog.py
+++ b/bread_cog.py
@@ -7229,7 +7229,7 @@ anarchy - 1000% of your wager.
         brief="Sets the max prestige level.",
         help = "Usage: bread admin set_max_prestige_level [value]"
     )
-    @commands.is_owner()
+    @commands.check(verification.is_admin_check)
     async def set_max_prestige_level(self, ctx,
             value: typing.Optional[parse_int]
         ):

--- a/bread_cog.py
+++ b/bread_cog.py
@@ -5796,7 +5796,7 @@ anarchy - 1000% of your wager.
             items_added = []
 
             for win_item, win_amount in reward:
-                amount = math.ceil(win_amount * percent_cut)
+                amount = math.ceil(win_amount * (percent_cut - 0.2))
                 player_account.increment(win_item, amount)
 
                 items_added.append(f"{utility.smart_number(amount)} {win_item}")

--- a/bread_cog.py
+++ b/bread_cog.py
@@ -3422,6 +3422,7 @@ For example, "$bread gift Melodie all chess_pieces" would gift all your chess pi
                 amount = leftover
             if sender_account.has(item, amount):
                 receiver_account.increment("daily_gifts", amount)
+                self.json_interface.set_account(target, receiver_account, guild = ctx.guild.id)
             else:
                 await ctx.reply("Except you don't have that much dough to give. Too bad.")
                 return

--- a/enforcement.py
+++ b/enforcement.py
@@ -272,7 +272,7 @@ async def brick(ctx, member: typing.Optional[discord.Member], *args):
     forever = False
     authorized_user = False
 
-    if verification.has_role(ctx.author, "moderator") or verification.has_role(ctx.author, "deputized") or verification.is_owner(ctx.author):
+    if verification.has_role(ctx.author, "moderator") or verification.has_role(ctx.author, "deputized") or verification.has_role(ctx.author, "admin") or verification.is_owner(ctx.author):
         authorized_user = True
 
     if len(args) == 0:

--- a/enforcement.py
+++ b/enforcement.py
@@ -246,7 +246,10 @@ async def timeout(ctx: commands.Context, member: typing.Optional[discord.Member]
 
 brick_list = set()
 
-@commands.command()
+@commands.command(
+        brief = "The fabled unbrick.",
+        help = "Instructions read: only use in dire situations."
+)
 async def unbrick(ctx, member: typing.Optional[discord.Member]):
     if verification.has_role(ctx.author, "moderator") or verification.has_role(ctx.author, "deputized"):
         if member is None:

--- a/json_cog.py
+++ b/json_cog.py
@@ -415,6 +415,8 @@ async def setup(bot):
     #try:
         #Bread_cog.internal_load(bot)
     json_cog.internal_load()
+
+    bot.json_cog = json_cog_ref
     #except BaseException as err:
     #    print(err)
     #bot.add_cog(Chess_game(bot)) #do we want to actually have this be a *cog*, or just a helper class?

--- a/main.py
+++ b/main.py
@@ -35,7 +35,12 @@ intents.messages = True
 intents.guilds = True
 intents.message_content = True
 
-bot = utility.CustomBot(command_prefix=COMMAND_PREFIX, intents=intents, owner_id=OWNER_ID)
+bot = utility.CustomBot(
+    command_prefix=COMMAND_PREFIX,
+    intents=intents,
+    owner_id=OWNER_ID,
+    help_command = utility.CustomHelpCommand()
+)
 # bot = commands.Bot(command_prefix=COMMAND_PREFIX, intents=intents, owner_id=OWNER_ID)
 
 

--- a/talk.py
+++ b/talk.py
@@ -532,6 +532,41 @@ async def verify(ctx, user: typing.Optional[discord.Member]):
         
         await ctx.send(output + random.choice(descriptors))
 
+@commands.command(
+    brief = "Change ping reply settings",
+    help =  "Change your ping reply setting. 'on' to enable ping replies, 'off' to disable."
+)
+async def ping(
+        ctx: commands.Context,
+        setting: typing.Optional[str]
+    ):
+    try:
+        json_cog = ctx.bot.json_cog
+    except AttributeError:
+        await ctx.reply("Unable to change setting, please try again later.")
+        return
+    
+    new = None
+    if setting is not None:
+        if setting.lower() in ["on", "y", "yes", "enable"]:
+            new = True
+        elif setting.lower() in ["off", "n", "no", "disable"]:
+            new = False
+    
+    data = json_cog.get_filing_cabinet(name="ping_settings", guild=ctx.guild, create_if_nonexistent=True)
+
+    if new is None:
+        new = not data.get(str(ctx.author.id), True)
+
+    data[str(ctx.author.id)] = new
+
+    json_cog.set_filing_cabinet(name="ping_settings", guild=ctx.guild, cabinet=data)
+
+    if new:
+        await ctx.reply("You will now be pinged in replies.")
+    else:
+        await ctx.reply("You will no longer be pinged in replies.")
+
 async def setup(bot: commands.Bot):
     importlib.reload(verification)
     importlib.reload(emoji)
@@ -548,5 +583,6 @@ async def setup(bot: commands.Bot):
     bot.add_command(our)
     bot.add_command(dayum)
     bot.add_command(bingo)
+    bot.add_command(ping)
 
     return bot


### PR DESCRIPTION
Patch 27.12:

- Fixed '$bread hub' not working in some very specific situations.
- Fixed the down-ascension dough gifting limit not working at all.
- Fixed yet another project not appearing in Trade Hubs.
- Fixed the "You've bought everything here" message in the Hidden Bakery appearing when it shouldn't.
- Changed how project rewards are rounded to prevent certain rounding-related issues.
- Changed the underlying equation for corrupted bread, for the most part it will be similar to the old one, but some things will be slightly different.
- After far too long, you can now toggle whether the bot should use ping replies when replying to you via the new '$ping' command.
- Changed the required items to level up Trade Hubs.
- You can now provide subcommands in '$bread help', so '$bread help space' will be the same as '$help bread space'.
- Once again changed how Chessatron Contraption works. The new Chessatron dough equation is the following: `2000 + 100 * o * (1 + 0.02 * s)` where `o` is omegas and `s` is active shadowmegas.
- Changed the amount of Loaf Converters that each tier of Advanced Exploration will use, as well as reducing the maximum from 127 to 63.
- Bread Space is no longer restricted to only a9.

That last one leads into a big announcement:
The next ascension, a10, will be starting at the next Bread o' Clock, at <t:1733526300>.