### PR TITLE
Patch 29.4

### DIFF
--- a/bread/alchemy.py
+++ b/bread/alchemy.py
@@ -721,6 +721,10 @@ recipes = {
         {
             "cost": [(values.black_pawn, 1000), (values.gem_green, 10)],
             "requirement": [("space_level", 1)]
+        },
+        {
+            "cost": [(values.black_pawn, 250), (values.gem_pink, 3), (values.gem_cyan, 3)],
+            "requirement": [("space_level", 1)]
         }
     ],
 
@@ -731,6 +735,10 @@ recipes = {
         },
         {
             "cost": [(values.black_knight, 1000), (values.gem_green, 10)],
+            "requirement": [("space_level", 1)]
+        },
+        {
+            "cost": [(values.black_knight, 250), (values.gem_pink, 3), (values.gem_orange, 3)],
             "requirement": [("space_level", 1)]
         }
     ],
@@ -743,6 +751,10 @@ recipes = {
         {
             "cost": [(values.black_bishop, 1000), (values.gem_green, 10)],
             "requirement": [("space_level", 1)]
+        },
+        {
+            "cost": [(values.black_bishop, 250), (values.gem_orange, 3), (values.gem_cyan, 3)],
+            "requirement": [("space_level", 1)]
         }
     ],
 
@@ -753,6 +765,10 @@ recipes = {
         },
         {
             "cost": [(values.black_rook, 1000), (values.gem_green, 10)],
+            "requirement": [("space_level", 1)]
+        },
+        {
+            "cost": [(values.black_rook, 250), (values.gem_pink, 3), (values.gem_cyan, 3)],
             "requirement": [("space_level", 1)]
         }
     ],
@@ -765,6 +781,10 @@ recipes = {
         {
             "cost": [(values.black_queen, 1000), (values.gem_green, 10)],
             "requirement": [("space_level", 1)]
+        },
+        {
+            "cost": [(values.black_queen, 250), (values.gem_pink, 3), (values.gem_orange, 3)],
+            "requirement": [("space_level", 1)]
         }
     ],
 
@@ -775,6 +795,10 @@ recipes = {
         },
         {
             "cost": [(values.black_king, 1000), (values.gem_green, 10)],
+            "requirement": [("space_level", 1)]
+        },
+        {
+            "cost": [(values.black_king, 250), (values.gem_orange, 3), (values.gem_cyan, 3)],
             "requirement": [("space_level", 1)]
         }
     ],

--- a/bread/generation.py
+++ b/bread/generation.py
@@ -596,15 +596,8 @@ def generate_system(
     Returns:
         typing.Union[dict, None]: The data for the system in a dict if the tile has a system on it, otherwise None.
     """
-
-    ######################################################################################
-    ##### CHANGES MADE TO THIS WILL AFFECT EVERY SYSTEM, INCLUDING ONES ALREADY SEEN #####
-    ##### This is because the contents of systems are generated on-demand, and are   #####
-    ##### not stored in the database anywhere. Natural trade hubs that haven't been  #####
-    ##### levelled up should stay, however they may not spawn in the same location   #####
-    ##### before changes are made. Trade hubs that have been levelled up will stay.  #####
-    ##### Depending on where the change is made asteroid belts & planets may change. #####
-    ######################################################################################
+    
+    # Changes can be made to this and it won't overwrite already-seen things, as the map is stored in the database.
 
     gradient_info = generate_gradients(galaxy_seed)
     nebula_info = generate_nebulae(galaxy_seed)

--- a/bread/projects.py
+++ b/bread/projects.py
@@ -4300,7 +4300,7 @@ class Electrical_Issue(Project):
         return [(values.anarchy_black_knight.text, amount)]
     
 class Chess_Tournament(Project):
-    """Written by Kapola."""
+    """Concept by DUck, written by Kapola."""
     internal = "chess_tournament"
     
     @classmethod
@@ -5944,7 +5944,7 @@ class Gem_Mining(Project):
         return [(values.gem_red.text, amount)]
 
 class Jewelry_Store(Project):
-    """Written by Kapola."""
+    """Concept by Emily, written by Kapola."""
     internal = "jewelry_store"
     
     @classmethod
@@ -6068,7 +6068,7 @@ class Jewelry_Store(Project):
         return [(values.gem_blue.text, amount)]
 
 class Generator_Breakdown(Project):
-    """Written by Kapola."""
+    """Concept by Emily, written by Kapola."""
     internal = "generator_breakdown"
     
     @classmethod
@@ -6199,7 +6199,7 @@ class Generator_Breakdown(Project):
         return [(values.gem_purple.text, amount)]
 
 class Gem_Salesman(Project):
-    """Written by Kapola."""
+    """Concept by Emily, written by Kapola."""
     internal = "gem_salesman"
     
     @classmethod

--- a/bread/projects.py
+++ b/bread/projects.py
@@ -1949,9 +1949,9 @@ class Gem_Extraction(Project):
             (values.gem_purple.text, amount_1 * 7500),
             (values.gem_green.text, amount_1 * 3750),
             (values.gem_gold.text, amount_1 * 1875),
-            (values.gem_pink.text, amount_1 * 150),
-            (values.gem_orange.text, amount_1 * 150),
-            (values.gem_cyan.text, amount_1 * 150)
+            (values.gem_pink.text, amount_1 * 50),
+            (values.gem_orange.text, amount_1 * 50),
+            (values.gem_cyan.text, amount_1 * 50)
         ]
 
 class Bakery_Encounter(Project):

--- a/bread/projects.py
+++ b/bread/projects.py
@@ -4300,7 +4300,7 @@ class Electrical_Issue(Project):
         return [(values.anarchy_black_knight.text, amount)]
     
 class Chess_Tournament(Project):
-    """Concept by DUck, written by Kapola."""
+    """Concept by Duck, written by Kapola."""
     internal = "chess_tournament"
     
     @classmethod

--- a/bread/projects.py
+++ b/bread/projects.py
@@ -623,7 +623,7 @@ class Hyperlane_Registrar(Trade_Hub_Upgrade):
             system_tile: space.SystemTradeHub
         ) -> str:
         tier = system_tile.get_upgrade_level(cls)
-        return f"A powerful supercomputer aboard the Trade Hub that's able to crunch the numbers required to find more efficient ways to use your fuel.\nThis results in a {round(cls.cost_multipliers[tier + 1] * 100)}% fuel consumption reduction for anyone moving, if they start somewhere within this Trade Hub's radius.\n*If one player is within radius of multiple Trade Hubs only the best one is used, the effect does not stack.*"
+        return f"A powerful supercomputer aboard the Trade Hub that's able to crunch the numbers required to find more efficient ways to use your fuel.\nThis results in a {round((1 - cls.cost_multipliers[tier + 1]) * 100)}% fuel consumption reduction for anyone moving, if they start somewhere within this Trade Hub's radius.\n*If one player is within radius of multiple Trade Hubs only the best one is used, the effect does not stack.*"
     
     @classmethod
     def completion(

--- a/bread/projects.py
+++ b/bread/projects.py
@@ -2244,15 +2244,15 @@ class Corruption_Lab(Project):
         distance = math.hypot(system_tile.galaxy_xpos - space.MAP_RADIUS, system_tile.galaxy_ypos - space.MAP_RADIUS)
         
         if distance <= 2:
-            out += " `0.99`"
+            out += r" `0.99`"
         elif distance <= 80:
-            out += " `\left(\frac{\cos\left(\left(x-2\right)\frac{\pi}{78}\right)}{2}+0.5\right)0.99`"
+            out += r" `\left(\frac{\cos\left(\left(x-2\right)\frac{\pi}{78}\right)}{2}+0.5\right)0.99`"
         elif distance <= 87:
-            out += " `0`"
+            out += r" `0`"
         elif distance <= 241.81799:
-            out += " `\left(\frac{\cos\left(\frac{70055\left(x-87\right)\pi}{10845774}\right)}{-2}+0.5\right)0.99`"
+            out += r" `\left(\frac{\cos\left(\frac{70055\left(x-87\right)\pi}{10845774}\right)}{-2}+0.5\right)0.99`"
         else:
-            out += " `0.99`"
+            out += r" `0.99`"
 
         return out
     

--- a/bread/projects.py
+++ b/bread/projects.py
@@ -2112,7 +2112,7 @@ class Bakery_Encounter(Project):
 
         return [
             (values.croissant.text, amount_1 * 80000 - 300000),
-            (values.french_bread.text, amount_1 * 4000 - 150000),
+            (values.french_bread.text, amount_1 * 40000 - 150000),
             (rng.choice(values.all_rare_breads).text, amount_1 * 20000 - 75000)
         ]
 

--- a/bread/space.py
+++ b/bread/space.py
@@ -692,15 +692,39 @@ class SystemTradeHub(SystemTile):
             out.append("")
             out.append("Purchased upgrades:")
             
+            found = False
             for upgrade in projects.all_trade_hub_upgrades:
                 if self.get_upgrade_level(upgrade):
+                    found = True
                     out.append(f"- {upgrade.name(day_seed, self)} level {self.get_upgrade_level(upgrade)}")
+                    
+            if not found:
+                out.append("*None*")
+                
                     
             out.append("")
             out.append("Available upgrades:")
             
+            found = False
             for upgrade in self.get_available_upgrades(day_seed):
+                found = True
                 out.append(f"- {upgrade.name(day_seed, self)}")
+                
+            if not found:
+                out.append("*None*")
+                
+            out.append("")
+            out.append("Available projects:")
+            
+            available_projects = get_trade_hub_projects(
+                json_interface = json_interface,
+                user_account = user_account,
+                system_tile = self
+            )
+            for project_data in available_projects:
+                project = project_data.get("project")
+                
+                out.append(f"- {project.name(day_seed, self)}")
                 
             out.append("")
         else:

--- a/bread/space.py
+++ b/bread/space.py
@@ -3353,20 +3353,15 @@ def get_move_cost_galaxy(
     cost_sum = 0
 
     through_nebula = False
-
-    map_data = json_interface.get_space_map_data(
-        ascension_id = ascension,
-        guild = guild
-    )
+    
+    seed = json_interface.get_ascension_seed(ascension, guild)
+    nebulae_data = generation.generate_nebulae(galaxy_seed=seed)
     
     for x, y in points:
-        nebula = in_nebula_database(
-            json_interface = json_interface,
-            guild = guild,
-            ascension = ascension,
-            xpos = x,
-            ypos = y,
-            map_data = map_data
+        nebula = generation.in_nebula(
+            nebulae_info = nebulae_data,
+            x = x - MAP_RADIUS,
+            y = y - MAP_RADIUS
         )
 
         if nebula:

--- a/bread_cog.py
+++ b/bread_cog.py
@@ -6023,6 +6023,24 @@ anarchy - 1000% of your wager.
 
 
         ##########
+        # Going through with contributing.
+        
+        # Refresh the project data in case anything has changed between when it originally was fetched.
+        # Two people contributing at the same time can cause this to be the case.
+        hub_projects = space.get_trade_hub_projects(
+            json_interface = self.json_interface,
+            user_account = user_account,
+            system_tile = hub
+        )
+        project_data = hub_projects[project_number - 1]
+        
+        if project_data.get("completed", False):
+            await ctx.reply("This project has already been completed.")
+            return
+        
+        project = project_data.get("project") # type: projects.Project
+        contribution_data = project_data.get("contributions", [])
+        player_data = contribution_data.get(str(ctx.author.id), {"items": {}})
 
         user_account.increment("hub_credits", -credits_used)
         


### PR DESCRIPTION
- Fixed completion text for the Corruption Lab project.
- Fixed broken reward scheme for the Bakery Encounter project.
- Fixed two people contributing to a project at the same time overwriting the data.
- Fixed being able to move into nebulae if the destination tile hasn't been generated.
- Tweak Hyperlane Registrar description to be more clear.
- Decrease space gem reward for Gem Extraction project.
- Projects are now credited properly internally.
- Added alchemy recipes to the black anarchy pieces that use space gems, similar to the white anarchy pieces.
- The name of available projects are now shown in a detailed Trade Hub analysis.