### PR TITLE
Hotfix 29.6

### DIFF
--- a/bread/generation.py
+++ b/bread/generation.py
@@ -647,9 +647,19 @@ def generate_system(
     asteroid_belt = rng.randint(1, 3) == 1 # 1 in 3 chance of an asteroid belt.
 
     if asteroid_belt:
-        asteroid_belt_distance = rng.randint(2, math.ceil(planet_count ** 0.85) + 1)
+        asteroid_count = max(round(rng.normalvariate(1, 1)), 1)
+        
+        asteroid_belts = []
+        
+        for asteroid_id in range(asteroid_count):
+            if asteroid_belts:
+                minimum = min(asteroid_belts) + 2
+            else:
+                # Not too clsoe to the star.
+                minimum = 2
+            asteroid_belts.append(rng.uniform(minimum, math.ceil(planet_count ** 0.85) + 1))
     else:
-        asteroid_belt_distance = planet_count + 2
+        asteroid_belts = []
 
     for planet_id in range(planet_count):
         planet_rng = random.Random(hashlib.sha256(str(galaxy_seed + str(galaxy_ypos) + str(galaxy_xpos) + "planet" + str(planet_id)).encode()).digest())
@@ -666,7 +676,7 @@ def generate_system(
             sigma = 0.1
         )
 
-        modified_id = planet_id + (1 if planet_id - 1 >= asteroid_belt_distance else 0)
+        modified_id = planet_id + sum([planet_id - 1 >= belt for belt in asteroid_belts])
 
         planet_distance = 2 + (modified_id + 1.5)# ** 1.712 # dont ask why that number lol
 
@@ -783,8 +793,7 @@ def generate_system(
         "wormhole": wormhole_data,
         "radius": math.ceil(largest_distance) + 1,
         "star_type": star_type,
-        "asteroid_belt": asteroid_belt,
-        "asteroid_belt_distance": asteroid_belt_distance,
+        "asteroid_belts": asteroid_belts,
         "planets": planets
     }
 

--- a/bread/values.py
+++ b/bread/values.py
@@ -212,6 +212,7 @@ doughnut = Emote(
     name="doughnut",
     emoji= "🍩",
     attributes=["rare_bread"],
+    alternate_names=["donut"]
 )
 
 # bagel = {
@@ -1063,6 +1064,8 @@ def get_emote(text: str) -> typing.Optional[Emote]:
     """Returns an Emote object if the given text represents that emote, or None if no emote matches."""
     if text is None:
         return None
+    if isinstance(text, Emote):
+        return text
     if len(text) == 0:
         return None
     # return None

--- a/bread_cog.py
+++ b/bread_cog.py
@@ -1358,7 +1358,8 @@ class Bread_cog(commands.Cog, name="Bread"):
         chess_keywords = ["chess", "chess pieces", "pieces"]
         gambit_keywords = ["gambit", "strategy", "gambit shop", "strategy shop"]
         space_keywords = ["space"]
-        all_keywords = archive_keywords + chess_keywords + gambit_keywords + space_keywords
+        item_keywords = ["item", "items", "inventory"]
+        all_keywords = archive_keywords + chess_keywords + gambit_keywords + space_keywords + item_keywords
 
         if user is not None and modifier is None:
             names = [user.name, user.nick, user.global_name, user.display_name]
@@ -1389,6 +1390,37 @@ class Bread_cog(commands.Cog, name="Bread"):
         # bread stats space
         if (modifier is not None) and modifier.lower() in space_keywords:
             await self.space_stats(ctx, user)
+            return
+
+        # bread stats items
+        if (modifier is not None) and modifier.lower() in item_keywords:
+            output = f"Item stats of {user_account.get_display_name()}:\n\n"
+            
+            if user_account.has(":bread:"):
+                output += f":bread: - {utility.smart_number(user_account.get(':bread:'))}\n"
+
+            display_list = ["special_bread", "rare_bread", "misc_bread", "shiny", "shadow", "misc", "unique" ]
+
+            #iterate through all the display list and print them
+            for item_name in display_list:
+
+                display_items = user_account.get_all_items_with_attribute(item_name)
+
+                for item in display_items:
+                    if not user_account.has(item.text):
+                        continue
+                    
+                    output += f"{utility.smart_number(user_account.get(item.text))} {item.text} , "
+                
+                # Remove the last `, ` if it exists.
+                output = output.removesuffix(", ")
+                
+                # If there isn't a `\n` at the end, add one.
+                # There will be a `\n` at the end if we didn't add anything in this iteration.
+                if not output.endswith("\n"):
+                    output += "\n"
+            
+            await ctx.reply(output)
             return
 
         # bread stats chess

--- a/bread_cog.py
+++ b/bread_cog.py
@@ -1240,6 +1240,11 @@ class Bread_cog(commands.Cog, name="Bread"):
             user: typing.Optional[discord.Member] = commands.parameter(description = "The user to get the stats of."),
             archived: typing.Optional[str] = commands.parameter(description = "Use 'archived' to use the archived data.")
             ):
+        items = {}
+        for item in values.all_emotes:
+            items[item.text] = len(item.text)
+        print(items)
+        print(list(sorted(items, key=items.get)))
         #print("stats called for user "+str(user))
 
         check_archive = False
@@ -2295,7 +2300,7 @@ loaf_converter""",
                         potential_addition = roll_messages.pop()
 
                         # check to make sure we don't hit the length limit
-                        if len(compound_message) + len(potential_addition) > 1900:
+                        if len(compound_message) + len(potential_addition) > 1990:
                             # put it back on the list if it would be too long
                             roll_messages.append(potential_addition)
                             continue


### PR DESCRIPTION
- Multiple asteroid belt rings can now be generated (Duck thought this was already the case, but apparently it wasn't.)
- "donut" is now an alias for doughnuts.
- Added '$bread stats items', which will send just the items section of the regular stats.
- The bot should not longer break if an all corrupted bread lottery is rolled.