### PR TITLE
Patch 30

### DIFF
--- a/bread/gamble.py
+++ b/bread/gamble.py
@@ -6,10 +6,13 @@ import discord.ext.commands as commands
 import itertools
 import typing
 import random
+import abc
+import time
 
 import bread.account as account
 import bread.values as values
 import bread.utility as utility
+import bread.store as store
 
 EMPTY = ":black_medium_square:"
 
@@ -22,7 +25,7 @@ EMOJI_LEFT_ARROW = ":arrow_backward:"
 EMOJI_BLUE_SQUARE = ":blue_square:"
 EMOJI_RED_SQUARE = ":red_square:"
 
-class GameBoard:
+class GameBoard():
     """Represents a rectangular game board with a set number of rows and columns."""
     
     def __init__(
@@ -34,6 +37,9 @@ class GameBoard:
         self.rows = rows
         self.columns = columns
         self.board = [[filler for _ in range(columns)] for _ in range(rows)]
+    
+    def __str__(self):
+        return f"<GameBoard: {self.board}>"
     
     ############################################
     # Getters.
@@ -185,7 +191,7 @@ class GameBoard:
 ####################################################################################################################
 ####################################################################################################################
 
-class Game:
+class Game(abc.ABC):
     board_size = (4, 4)
     option_data: dict[typing.Any, float | int ] = {
         values.horsey.text: 25,
@@ -195,7 +201,7 @@ class Game:
     
     def __init__(
             self: typing.Self,
-            wager: int | tuple[str | values.Emote, int] | typing.Any,
+            wager: int | tuple[str | values.Emote, int] | values.Emote | typing.Any,
             json_interface: bread_cog.JSON_interface,
             ctx: commands.Context
         ) -> None:
@@ -234,10 +240,12 @@ class Game:
         # Now that things have been setup, send and store the initial message.
         self.message = await self.ctx.reply(self.board.format_board())
     
+    @abc.abstractmethod
     async def run_tick(self: typing.Self) -> None:
         """Run every 1.5 seconds to update the game state."""
-        pass
+        raise NotImplementedError("run_tick() must be implemented in subclasses.")
     
+    @abc.abstractmethod
     async def finish(
             self: typing.Self,
             footer: str = None
@@ -366,3 +374,363 @@ class BaseGame(Game):
         if do_brick:
             # insert trol emoji here
             await self.ctx.invoke(self.ctx.bot.get_command('brick'), member=self.ctx.author)
+
+            
+####################################################################################################################
+##### LASERS GAME.
+
+class LasersBoard(GameBoard):
+    def format_board(
+            self: typing.Self,
+            tease_info: tuple[int, int] | None = None,
+            laser_info: tuple[int, int] | None = None
+        ) -> str:
+        """Formats the board.
+
+        Args:
+            tease_info (tuple[int, int] | None, optional): Row and column (in that order) of the tiles to tease. Defaults to None.
+            laser_info (tuple[int, int] | None, optional): Row and column (in that order) of the tiles to laser. Defaults to None.
+
+        Returns:
+            str: The formatted board.
+        """
+        render_mod = self.board.copy()
+        
+        # Unpack tease and laser info.
+        tease_row, tease_column = tease_info or (None, None)
+        laser_row, laser_column = laser_info or (None, None)
+            
+        for row_index, row in enumerate(render_mod):
+            if row_index == laser_row:
+                row = [EMOJI_RED_SQUARE] * len(row)
+            elif laser_column is not None:
+                row[laser_column] = EMOJI_RED_SQUARE
+            
+            if row_index == tease_row:
+                row = [EMOJI_RIGHT_ARROW] + row + [EMOJI_LEFT_ARROW]
+            else:
+                row = [EMOJI_BLUE_SQUARE] + row + [EMOJI_BLUE_SQUARE]
+                
+            render_mod[row_index] = row
+        
+        render_mod.insert(0,
+            [EMOJI_DOWN_ARROW if index - 1 == tease_column else EMOJI_BLUE_SQUARE for index in range(self.columns + 2)]
+        )
+        render_mod.append(
+            [EMOJI_UP_ARROW if index - 1 == tease_column else EMOJI_BLUE_SQUARE for index in range(self.columns + 2)]
+        )
+        
+        return "\n".join(["".join(line) for line in render_mod])
+
+class LasersGame(Game):
+    board_size = (6, 6)
+    
+    option_data = {
+        values.brick.text: 4,
+        values.hotdog.text: 19,
+        values.cherry.text: 26,
+        values.normal_bread.text: 25,
+        values.french_bread.text: 15,
+        values.pretzel.text: 10,
+        values.birthday.text: 1
+    }
+    
+    async def setup(self: typing.Self) -> None:
+        """Run when the game is created, can be used to configure settings and remove the initial wager."""
+        self.winning_item = None
+        
+        self.board = LasersBoard(*self.board_size)
+        self.fake_board = LasersBoard(*self.board_size)
+        
+        
+        # Setup the variables used later.
+        self.remove_row = None
+        self.remove_column = None
+        self.shift_chosen = None
+        
+        self.shift_options = [
+            self.board.shift_up,
+            self.board.shift_down,
+            self.board.shift_left,
+            self.board.shift_right
+        ]
+        self.fake_shift_options = [
+            self.fake_board.shift_up,
+            self.fake_board.shift_down,
+            self.fake_board.shift_left,
+            self.fake_board.shift_right
+        ]
+        self.shift_opposite = {
+            self.board.shift_up: self.board.shift_down,
+            self.board.shift_down: self.board.shift_up,
+            self.board.shift_left: self.board.shift_right,
+            self.board.shift_right: self.board.shift_left
+        }
+        self.fake_shift_opposite = {
+            self.fake_board.shift_up: self.fake_board.shift_down,
+            self.fake_board.shift_down: self.fake_board.shift_up,
+            self.fake_board.shift_left: self.fake_board.shift_right,
+            self.fake_board.shift_right: self.fake_board.shift_left
+        }
+        
+        user_account = self.json_interface.get_account(self.ctx.author.id, self.ctx.guild.id) # type: account.Bread_Account
+        user_account.increment(self.wager, -1)
+        self.json_interface.set_account(self.ctx.author.id, user_account, self.ctx.guild.id)
+        
+        try:
+            self.active_catalyst = user_account.get_active_catalyst().name
+        except AttributeError:
+            self.active_catalyst = None
+        
+        self.random_seed = time.time()# * user_account.get("earned_dough")
+        self.random_obj = random.Random(self.random_seed)
+        
+        equal_weight = {i.text: 1 for i in filler_items}
+        
+        
+        ##############################
+        
+        items = {}
+        for key, item_list in salvage_weights.items():
+            if self.wager in key:
+                items = dict(item_list)
+                break
+        else:
+            raise KeyError(f"Unable to find item {self.wager} in the salvage weights list.")
+        
+        self.board.populate(equal_weight.keys(), equal_weight.values())
+        
+        for column in range(self.board_size[0]):
+            for row in range(self.board_size[1]):
+                self.fake_board.set_cell(row, column, column * self.board_size[0] + row)
+                
+        ##############################
+        
+        self.remove_coordinates = [] # type: list[tuple[int, int]]
+        self.shifts = [] # type: list[typing.Callable]
+        
+        # self.winning_item = values.croissant
+        
+        self.tick_is_real = False
+        
+        while self.in_progress:
+            await self.run_tick()
+        
+        winning_id = self.fake_board.get_cell(self.fake_board.get_remaining_rows()[0], self.fake_board.get_remaining_columns()[0])
+        winning_coordinates = (winning_id % self.board_size[0], winning_id // self.board_size[0])
+        
+        # Reset all the stuff that's modified while running the initial ticks.
+        self.tick = 0
+        self.in_progress = True
+        self.tick_is_real = True
+        self.random_obj = random.Random(self.random_seed)
+        
+        ##############################
+        # Now that we know which tile is going to win, we can finally populate the regular board correctly.
+        # The winning tile will *always* be chosen from the wager-specific item list, and a random amount of other tiles will be as well.
+        
+        if len(items) >= 2:
+            amount = round(random.normalvariate(self.board_size[0] * self.board_size[1] / 2, self.board_size[0] * self.board_size[1] / 6))
+            
+            print(f"[Salvage] Replacing {amount} items on the board.")
+            
+            # Limit the bounds of the amount to be within a reasonable range.
+            amount = min(max(amount, 5), self.board_size[0] * self.board_size[1])
+            
+            items_add = random.choices(list(items.keys()), weights=list(items.values()), k=amount)
+            
+            for index, item in enumerate(items_add):
+                if self.active_catalyst == store.Aquila.name and item == values.gem_white.text:
+                    item = values.ephemeral_token.text
+                elif self.active_catalyst == store.Cygnus.name and item == values.ephemeral_token.text:
+                    item = values.gem_white.text
+                    
+                if index == 0:
+                    self.board.set_cell(*winning_coordinates, item)
+                    continue
+                
+                column = random.randrange(self.board_size[0])
+                row = random.randrange(self.board_size[1])
+                
+                self.board.set_cell(row, column, item)
+        else:
+            self.board.populate(items.keys(), items.values())
+            
+        self.winning_item = values.get_emote(self.board.get_cell(*winning_coordinates))
+            
+        print(user_account.get("username"), f"is salvaging a {self.wager} and will win a {self.winning_item}.")
+        
+        ##############################
+        
+        self.message = await self.ctx.reply(self.board.format_board())
+        
+    
+    async def run_tick(self: typing.Self) -> None:
+        action = self.tick % 3
+        
+        if self.tick_is_real:
+            board_use = self.board
+            shift_options = self.shift_options
+            shift_opposite = self.shift_opposite
+        else:
+            board_use = self.fake_board
+            shift_options = self.fake_shift_options
+            shift_opposite = self.fake_shift_opposite
+        
+        if action == 0:
+            # If the action is 0:
+            # - Remove anything if there is stuff to remove.
+            # - Figure out what we're gonna remove and how we're gonna shift
+            # - Tease it.
+            if self.tick != 0:
+                board_use.remove_row(self.remove_row)
+                board_use.remove_column(self.remove_column)
+                
+                if board_use.get_remaining() <= 1:
+                    self.in_progress = False
+            
+            if self.in_progress:
+                if self.tick_is_real:
+                    self.shift_chosen = shift_options[self.shifts.pop(0)]
+                    self.remove_row, self.remove_column = self.remove_coordinates.pop(0)
+                    
+                    rendered = board_use.format_board(tease_info=(self.remove_row, self.remove_column))
+                else:
+                    self.shift_chosen = self.random_obj.choice(shift_options)
+                    self.shift_chosen()
+                    
+                    possible_rows = board_use.get_remaining_rows()
+                    possible_columns = board_use.get_remaining_columns()
+                    
+                    shift_opposite[self.shift_chosen]()
+                    
+                    if len(possible_rows) > 1:
+                        self.remove_row = self.random_obj.choice(possible_rows)
+                    else:
+                        # If there's only 1 option left, choose something that is not it.
+                        self.remove_row = self.random_obj.randrange(self.board_size[1])
+                        
+                        while self.remove_row == possible_rows[0]:
+                            self.remove_row = self.random_obj.randrange(self.board_size[1])
+                    
+                    if len(possible_columns) > 1:
+                        self.remove_column = self.random_obj.choice(possible_columns)
+                    else:
+                        # If there's only 1 option left, choose something that is not it.
+                        self.remove_column = self.random_obj.randrange(self.board_size[0])
+                        
+                        while self.remove_column == possible_columns[0]:
+                            self.remove_column = self.random_obj.randrange(self.board_size[0])
+                    
+                    self.shifts.append(shift_options.index(self.shift_chosen))
+                    self.remove_coordinates.append((self.remove_row, self.remove_column))
+            else:
+                if self.tick_is_real:
+                    rendered = board_use.format_board()
+
+        elif action == 1:
+            # If the action is 1, shift the board.
+            self.shift_chosen()
+            
+            if self.tick_is_real:
+                rendered = board_use.format_board(tease_info=(self.remove_row, self.remove_column))
+            
+        else:
+            # If the action is 2 (this), show the lasers.
+            if self.tick_is_real:
+                rendered = board_use.format_board(
+                    tease_info=(self.remove_row, self.remove_column),
+                    laser_info=(self.remove_row, self.remove_column)
+                )
+        
+        if self.tick_is_real:
+            await self.message.edit(content=rendered)
+            
+        self.tick += 1
+    
+    async def finish(
+            self: typing.Self,
+            footer: str = None
+        ) -> None:
+        if footer is None:
+            footer = ""
+            
+        self.in_progress = False
+            
+        user_account = self.json_interface.get_account(self.ctx.author.id, self.ctx.guild.id) # type: account.Bread_Account
+        
+        if self.winning_item is None:
+            send_text = f"Hold up, something seems to have gone wrong and the Salvage Machine couldn't be started.\nWell, I suppose I can at least refund you the {self.wager.text} you put into it."
+                
+            user_account.increment(self.wager.text, 1)
+            user_account.increment("salvagez_remaining", 1)
+        else:
+            out_amount = 1
+            
+            if self.active_catalyst == store.Gemini.name and random.randint(1, 4) == 1:
+                out_amount = 2
+                
+            send_text = f"The salvage machine has managed to extract {out_amount} {self.winning_item.text} from the {self.wager.text}"
+            
+            # Little easter egg for certain items.
+            if self.winning_item in {values.gem_white, values.ephemeral_token, values.anarchy_omega_chessatron, values.anarchy_chessatron, values.hotdog} \
+                or out_amount > 1:
+                send_text += "!"
+            else:
+                send_text += "."
+                
+            user_account.increment(self.winning_item.text, out_amount)
+        
+        self.json_interface.set_account(self.ctx.author.id, user_account, self.ctx.guild.id)
+        
+        await self.ctx.reply(send_text + footer)
+        
+
+####################################################################################################################
+##### SALVAGE WEIGHTS.
+
+salvage_weights = {
+    (values.gem_white,): [(values.gem_white.text, 45), (values.ephemeral_token.text, 25), (values.gem_gold.text, 10), (values.gem_green.text, 5), (values.anarchy_chess.text, 5)] + [(gem.text, 10/3) for gem in values.all_very_shinies],
+    (values.ephemeral_token,): [(values.gem_white.text, 50), (values.ephemeral_token.text, 25), (values.anarchy_chessatron.text, 20), (values.anarchy_chess.text, 5)],
+    (values.gem_pink,): [(values.gem_white.text, 25), (values.ephemeral_token.text, 15), (values.gem_cyan.text, 30), (values.gem_orange.text, 30)],
+    (values.gem_orange,): [(values.gem_white.text, 25), (values.ephemeral_token.text, 15), (values.gem_cyan.text, 30), (values.gem_pink.text, 30)],
+    (values.gem_cyan,): [(values.gem_white.text, 25), (values.ephemeral_token.text, 15), (values.gem_orange.text, 30), (values.gem_pink.text, 30)],
+    (values.gem_gold,): [(values.gem_white.text, 15), (values.ephemeral_token.text, 10), (values.gem_cyan.text, 10), (values.gem_orange.text, 10), (values.gem_pink.text, 10), (values.gem_green.text, 30), (values.gem_purple.text, 15)],
+    (values.gem_green,): [(values.gem_white.text, 10), (values.ephemeral_token.text, 7), (values.gem_gold.text, 30), (values.gem_purple.text, 53)],
+    (values.gem_purple,): [(values.gem_white.text, 7), (values.ephemeral_token.text, 5), (values.gem_gold.text, 10), (values.gem_green.text, 20), (values.gem_blue.text, 34)] + [(piece.text, 2) for piece in values.all_anarchy_pieces],
+    (values.gem_blue,): [(values.gem_white.text, 5), (values.ephemeral_token.text, 2), (values.gem_gold.text, 5), (values.gem_green.text, 15), (values.gem_purple.text, 30), (values.gem_red.text, 43)],
+    (values.gem_red,): [(values.gem_white.text, 2), (values.ephemeral_token.text, 1), (values.gem_gold.text, 2), (values.gem_green.text, 10), (values.gem_purple.text, 15), (values.gem_blue.text, 22)] + [(piece.text, 4) for piece in values.all_chess_pieces],
+    tuple(values.anarchy_pieces_white,): [(values.anarchy_chessatron.text, 2.5)] + [(piece.text, 65/6) for piece in values.anarchy_pieces_white] + [(piece.text, 25/6) for piece in values.anarchy_pieces_black] + [(gem.text, 7.5/3) for gem in values.all_very_shinies],
+    tuple(values.anarchy_pieces_black,): [(values.anarchy_chessatron.text, 2.5)] + [(piece.text, 65/6) for piece in values.anarchy_pieces_black] + [(piece.text, 25/6) for piece in values.anarchy_pieces_white] + [(gem.text, 7.5/3) for gem in values.all_very_shinies],
+    tuple(values.chess_pieces_white,): [(values.chessatron.text, 2.5), (values.gem_red.text, 7.5)] + [(piece.text, 65/6) for piece in values.chess_pieces_white] + [(piece.text, 25/6) for piece in values.chess_pieces_black],
+    tuple(values.chess_pieces_black,): [(values.chessatron.text, 2.5), (values.gem_red.text, 7.5)] + [(piece.text, 65/6) for piece in values.chess_pieces_black] + [(piece.text, 25/6) for piece in values.chess_pieces_white],
+    tuple(values.all_rare_breads,): [(values.normal_bread.text, 10), (values.corrupted_bread.text, 5)] + [(bread.text, 65/3) for bread in values.all_rare_breads] + [(bread.text, 20/5) for bread in values.all_special_breads],
+    tuple(values.all_special_breads,): [(values.normal_bread.text, 10), (values.corrupted_bread.text, 5)] + [(bread.text, 20/3) for bread in values.all_rare_breads] + [(bread.text, 13) for bread in values.all_special_breads],
+    (values.normal_bread,): [(values.corrupted_bread.text, 12), (values.gem_white.text, 2), (values.ephemeral_token.text, 1)] + [(bread.text, 5) for bread in values.all_rare_breads] + [(bread.text, 14) for bread in values.all_special_breads],
+    (values.corrupted_bread,): [(values.corrupted_bread.text, 75), (values.normal_bread.text, 25)],
+    (values.horsey,): [(values.holy_hell.text, 50), (values.anarchy.text, 50)],
+    (values.holy_hell,): [(values.anarchy.text, 50), (values.horsey.text, 50)],
+    (values.anarchy,): [(values.holy_hell.text, 50), (values.horsey.text, 50)],
+    (values.anarchy_chess,): [(values.gem_white.text, 20), (values.ephemeral_token.text, 15), (values.omega_chessatron.text, 30), (values.gem_gold.text, 20), (values.anarchy_chessatron.text, 10), (values.anarchy_omega_chessatron.text, 5)],
+    (values.chessatron,): [(values.omega_chessatron.text, 18), (values.anarchy_chessatron.text, 10)] + [(piece.text, 4) for piece in values.chess_pieces_white] + [(piece.text, 12) for piece in values.chess_pieces_black],
+    (values.anarchy_chessatron,): [(values.omega_chessatron.text, 18), (values.anarchy_chessatron.text, 10), (values.hotdog.text, 5)] + [(piece.text, 4) for piece in values.anarchy_pieces_white] + [(piece.text, 43/6) for piece in values.anarchy_pieces_black],
+    (values.fuel,): [(values.gem_red.text, 50), (values.gem_blue.text, 25), (values.gem_purple.text, 13), (values.gem_green.text, 7), (values.gem_gold.text, 5)],
+    (values.cookie,): [(values.cookie.text, 50), (values.pretzel.text, 25), (values.fortune_cookie.text, 15), (values.pancakes.text, 10)],
+    (values.pretzel,): [(values.cookie.text, 25), (values.pretzel.text, 50), (values.fortune_cookie.text, 15), (values.pancakes.text, 10)],
+    (values.fortune_cookie,): [(values.cookie.text, 10), (values.pretzel.text, 25), (values.fortune_cookie.text, 50), (values.pancakes.text, 15)],
+    (values.pancakes,): [(values.cookie.text, 10), (values.pretzel.text, 15), (values.fortune_cookie.text, 25), (values.pancakes.text, 50)],
+    (values.omega_chessatron,): [(values.gem_white.text, 15), (values.ephemeral_token.text, 10), (values.anarchy_omega_chessatron.text, 10), (values.anarchy_chess.text, 40), (values.gem_gold.text, 25)],
+    (values.anarchy_omega_chessatron,): [(values.gem_white.text, 40), (values.ephemeral_token.text, 30), (values.omega_chessatron.text, 30)],
+    (values.hotdog,): [(values.hotdog.text, 95), (values.anarchy_chessatron.text, 5)],
+    (values.ascension_token,): [(values.ascension_token.text, 100)],
+    (values.middle_finger,): [(values.middle_finger.text, 100)],
+    (values.cherry,): [(values.cherry.text, 100)],
+    (values.rigged,): [(values.rigged.text, 100)],
+}
+
+# Every item that can be salvaged.
+salvage_options = list(itertools.chain.from_iterable(salvage_weights.keys()))
+
+# Every item that can show up as filler in a salvage.
+filler_items = [values.gem_white, values.ephemeral_token, values.anarchy_chess, values.normal_bread, values.corrupted_bread, values.chessatron, values.anarchy_chessatron, values.omega_chessatron, values.anarchy_omega_chessatron, values.fuel, values.hotdog] \
+    + values.all_very_shinies + values.all_shinies + values.all_anarchy_pieces + values.all_chess_pieces + values.all_rare_breads + values.all_special_breads

--- a/bread/projects.py
+++ b/bread/projects.py
@@ -379,7 +379,9 @@ class Trade_Hub(Project):
             "It was recently discovered by Trade Hub officials that an individual by the name of Meta had the permissions required to access many of the internal Trade Hub rooms, including very high security rooms, despite being a regular Trade Hub employee.",
             "The Trade Hub's power recently cut for a few minutes, causing widespread panic. After a minute, engineers discovered a critical flaw in a supply and demand calculation, which was somehow getting this weird number '60' after calculating 59 + 1.",
             "A fight broke out in the Trade Hub cafeteria in the early hours of the day after one member of the Trade Hub staff got tricked. The incident report stated 'Juno was mad, he knew he'd been had.'",
-            "Reports of a mysterious Timothy \"Cheater Cheater Lightbulb Eater\" Sands fellow appearing at random times around the Trade Hub is very concerning, but local LED consumption experts are confident that it's a good omen."
+            "Reports of a mysterious Timothy \"Cheater Cheater Lightbulb Eater\" Sands fellow appearing at random times around the Trade Hub is very concerning, but local LED consumption experts are confident that it's a good omen.",
+            "There is an excess of boinge in the Trade Hub.",
+            "The entire Trade Hub went offline temporarily after someone yelled a little too loud about seeing the number 37 show up.",
         ]
 
         out = "\n"
@@ -966,9 +968,9 @@ class Detection_Array(Trade_Hub_Upgrade):
         new_tier = system_tile.get_upgrade_level(cls) + 1
         
         if new_tier >= 2:
-            return f"Version {round(7.2 * (1.2 ** (new_tier - 2)), 1)} of some high-powered external sensors, capable of recieving communication network signals from {8 * (new_tier + 1)} tiles away."
+            return f"Version {round(7.2 * (1.2 ** (new_tier - 2)), 1)} of some high-powered external sensors, capable of receiving communication network signals from {8 * (new_tier + 1)} tiles away."
         
-        return f"High-powered suite of external sensors, capable of recieving communication network signals from {8 * (new_tier + 1)} tiles away."
+        return f"High-powered suite of external sensors, capable of receiving communication network signals from {8 * (new_tier + 1)} tiles away."
     
     @classmethod
     def completion(
@@ -998,7 +1000,7 @@ class Detection_Array(Trade_Hub_Upgrade):
         ) -> str:
         current_tier = system_tile.get_upgrade_level(cls)
         return f"A set of powerful sensors that increases this Trade Hub's range in the communication network to {8 * (current_tier + 1)} tiles."
-   
+ 
 class Dimensional_Shrine(Trade_Hub_Upgrade):
     internal = "dimensional_shrine"
     max_level = 1
@@ -1057,10 +1059,70 @@ class Dimensional_Shrine(Trade_Hub_Upgrade):
         
         # This one is only purchasable if the hub has any level of Offpsing Outlook.
         return bool(system_tile.get_upgrade_level(Offspring_Outlook))
+ 
+class Salvage_Works(Trade_Hub_Upgrade):
+    internal = "salvage_works"
+    max_level = 3
+    unlock_level = 5
     
+    per_level = 5
+    
+    @classmethod
+    def name(
+            cls,
+            day_seed: str,
+            system_tile: space.SystemTradeHub
+        ) -> str:
+        return "Salvage Works"
+
+    @classmethod
+    def description(
+            cls,
+            day_seed: str,
+            system_tile: space.SystemTradeHub
+        ) -> str:
+        existing_level = system_tile.get_upgrade_level(cls)
+        if existing_level == 0:
+            return "An advanced Salvage Machine capable of converting junk into useful resources."
+        
+        return f"An upgraded Salvage Machine that's able to salvage {5 + cls.per_level * existing_level} items per day before stopping."
+    
+    @classmethod
+    def completion(
+            cls: typing.Type[typing.Self],
+            day_seed: str,
+            system_tile: space.SystemTradeHub
+        ) -> str:        
+        return "The Salvage Machine is up and running! You can now use '$bread salvage' to interact with it."
+    
+    @classmethod
+    def get_cost(
+            cls,
+            day_seed: str,
+            system_tile: space.SystemTradeHub
+        ) -> list[tuple[str, int]]:
+        mult = system_tile.get_upgrade_level(cls) + 1
+        return [
+            (values.gem_cyan.text, 200 * mult), (values.gem_orange.text, 200 * mult), (values.gem_pink.text, 200 * mult),
+            (values.chessatron.text, 250 * mult), (values.anarchy_chessatron.text, 5 * mult)
+        ]
+    
+    @classmethod
+    def purchased_description(
+            cls: typing.Type[typing.Self],
+            day_seed: str,
+            system_tile: space.SystemTradeHub
+        ) -> str:
+        existing_level = system_tile.get_upgrade_level(cls)
+        
+        if existing_level == 1:
+            return "A Salvage Machine that can convert junk into useful resources."
+
+        return f"A Salvage Machine that can convert junk into useful resources, upgraded to salvage {5 + cls.per_level * (existing_level - 1)} items per day."
+ 
 all_trade_hub_upgrades = [Listening_Post, Nebula_Refinery, Quantum_Catapult, Hyperlane_Registrar, Shroud_Beacon,
     Dark_Matter_Resonance_Chamber, Black_Hole_Observatory, Storm_Repulsion_Array, Offspring_Outlook, Detection_Array,
-    Dimensional_Shrine
+    Dimensional_Shrine, Salvage_Works
 ] # type: list[Trade_Hub_Upgrade]
 
 #######################################################################################################

--- a/bread/space.py
+++ b/bread/space.py
@@ -222,7 +222,7 @@ PLANET_COLORS = {
     "Bknightanarchy": (0, 23, 60),
     "Bbishopanarchy": (0, 23, 60),
     "Brookanarchy": (0, 23, 60),
-    "Buqeenanarchy": (0, 23, 60),
+    "Bqueenanarchy": (0, 23, 60),
     "Bkinganarchy": (0, 23, 60),
 
     "Wpawnanarchy": (255, 156, 174),

--- a/bread/space.py
+++ b/bread/space.py
@@ -865,17 +865,17 @@ class SystemPlanet(SystemTile):
         )
 
         categories = {
-            "Special Bread": values.croissant,
-            "Rare Bread": values.bagel,
-            "Chess Piece": values.black_pawn,
+            "Special Breads": values.croissant,
+            "Rare Breads": values.bagel,
+            "Chess Pieces": values.black_pawn,
             "Red Gems": values.gem_red,
             "Blue Gems": values.gem_blue,
             "Purple Gems": values.gem_purple,
             "Green Gems": values.gem_green,
             "Gold Gems": values.gem_gold,
-            "Many of a Kind": values.anarchy_chess,
-            "Anarchy Piece": values.anarchy_black_pawn,
-            "Space gem": values.gem_pink
+            "Many of a Kinds": values.anarchy_chess,
+            "Anarchy Pieces": values.anarchy_black_pawn,
+            "Space Gems": values.gem_pink
         }
         deviation = self.planet_deviation
         

--- a/bread/utility.py
+++ b/bread/utility.py
@@ -63,6 +63,22 @@ def write_count(
         word =  word + delimiter + "s"
     output = smart_number(number) + " " + word
     return output
+            
+def list_items(items: list) -> str:
+    if len(items) == 1:
+        return items[0]
+    if len(items) == 0:
+        return ""
+    
+    joined = ", ".join(items)
+    
+    last_comma = joined.rsplit(",", 1)
+    
+    # Include the Oxford comma if the amount of items is not 2.
+    if len(items) == 2:
+        return " and".join(last_comma)
+    else:
+        return ", and".join(last_comma)
 
 def array_subtract(
         array1: list,

--- a/bread/values.py
+++ b/bread/values.py
@@ -1025,6 +1025,13 @@ ascension_token = Emote(
     name = "ascension_token",
     attributes = ["misc"],
     giftable = False
+
+)
+
+ephemeral_token = Emote(
+    text = "<:ephemeral_token:1362854706115772479>",
+    name = "ephemeral_token",
+    attributes = ["misc"]
 )
 
 fuel = Emote(
@@ -1050,7 +1057,7 @@ project_credits = Emote(
 
 all_bricks = [brick, brick_gold, fide_brick, brick_fide]
 all_bricks_weighted = [brick] * 10 + [brick_gold] * 1 + [fide_brick] * 5 + [brick_fide] * 5
-misc_emotes = [ascension_token, middle_finger, cherry, brick, brick_gold, fide_brick, brick_fide, lemon, grapes, rigged, bcapy, wcapy, corrupted_bread, fuel, gem_white] # gem_white is here so it won't get included in projects
+misc_emotes = [ascension_token, middle_finger, cherry, brick, brick_gold, fide_brick, brick_fide, lemon, grapes, rigged, bcapy, wcapy, corrupted_bread, fuel, gem_white, ephemeral_token] # gem_white is here so it won't get included in projects
 
 ##################### CODE
 


### PR DESCRIPTION
- Added a new Trade Hub upgrade unlocked at tier 5.
- Added `$bread reset_account` if you want to reset your account for some reason.
- Fuel is now shown in the item section of the space stats.
- High Roller Table has been moved from the Hidden Bakery to the regular Bread Shop. Everyone who purchased it in the past has received a refund.
- The gambit shop items will now, in their descriptions, show how much dough the item will be worth if you were to buy it.
- The white gem gambit shop item has been removed.
- Standardized category naming scheme in the planet analysis.
- Fixed systems with baqueen planets not being viewable on the full map.
- Fixed being able to spam `$bread hub contribute level full y` to level up a Trade Hub to tier 6, which would completely break it and both the galaxy and system map in the area.
- The code behind all the shops is now standardized, meaning all the shops should be formatted the same way. This will cause some slight differences from before in regards to line breaks, but everything else should be the same. Let me know if you find any issues.
- Other small internal changes, there should be no visual differences.